### PR TITLE
chore: bump to latest deck beta

### DIFF
--- a/amazon-locations/package.json
+++ b/amazon-locations/package.json
@@ -14,13 +14,13 @@
     "vite": "^4.5.0"
   },
   "dependencies": {
-    "@deck.gl/aggregation-layers": "^9.0.0-beta.1",
-    "@deck.gl/carto": "^9.0.0-beta.1",
-    "@deck.gl/core": "^9.0.0-beta.1",
-    "@deck.gl/extensions": "^9.0.0-beta.1",
-    "@deck.gl/geo-layers": "^9.0.0-beta.1",
-    "@deck.gl/layers": "^9.0.0-beta.1",
-    "@deck.gl/mesh-layers": "^9.0.0-beta.1",
+    "@deck.gl/aggregation-layers": "^9.0.0-beta.9",
+    "@deck.gl/carto": "^9.0.0-beta.9",
+    "@deck.gl/core": "^9.0.0-beta.9",
+    "@deck.gl/extensions": "^9.0.0-beta.9",
+    "@deck.gl/geo-layers": "^9.0.0-beta.9",
+    "@deck.gl/layers": "^9.0.0-beta.9",
+    "@deck.gl/mesh-layers": "^9.0.0-beta.9",
     "maplibre-gl": "^3.5.2"
   }
 }

--- a/boundaries/package.json
+++ b/boundaries/package.json
@@ -14,13 +14,13 @@
     "vite": "^4.5.0"
   },
   "dependencies": {
-    "@deck.gl/aggregation-layers": "^9.0.0-beta.1",
-    "@deck.gl/carto": "^9.0.0-beta.1",
-    "@deck.gl/core": "^9.0.0-beta.1",
-    "@deck.gl/extensions": "^9.0.0-beta.1",
-    "@deck.gl/geo-layers": "^9.0.0-beta.1",
-    "@deck.gl/layers": "^9.0.0-beta.1",
-    "@deck.gl/mesh-layers": "^9.0.0-beta.1",
+    "@deck.gl/aggregation-layers": "^9.0.0-beta.9",
+    "@deck.gl/carto": "^9.0.0-beta.9",
+    "@deck.gl/core": "^9.0.0-beta.9",
+    "@deck.gl/extensions": "^9.0.0-beta.9",
+    "@deck.gl/geo-layers": "^9.0.0-beta.9",
+    "@deck.gl/layers": "^9.0.0-beta.9",
+    "@deck.gl/mesh-layers": "^9.0.0-beta.9",
     "maplibre-gl": "^3.5.2"
   }
 }

--- a/carto-colors/package.json
+++ b/carto-colors/package.json
@@ -14,13 +14,13 @@
     "vite": "^4.5.0"
   },
   "dependencies": {
-    "@deck.gl/aggregation-layers": "^9.0.0-beta.1",
-    "@deck.gl/carto": "^9.0.0-beta.1",
-    "@deck.gl/core": "^9.0.0-beta.1",
-    "@deck.gl/extensions": "^9.0.0-beta.1",
-    "@deck.gl/geo-layers": "^9.0.0-beta.1",
-    "@deck.gl/layers": "^9.0.0-beta.1",
-    "@deck.gl/mesh-layers": "^9.0.0-beta.1",
+    "@deck.gl/aggregation-layers": "^9.0.0-beta.9",
+    "@deck.gl/carto": "^9.0.0-beta.9",
+    "@deck.gl/core": "^9.0.0-beta.9",
+    "@deck.gl/extensions": "^9.0.0-beta.9",
+    "@deck.gl/geo-layers": "^9.0.0-beta.9",
+    "@deck.gl/layers": "^9.0.0-beta.9",
+    "@deck.gl/mesh-layers": "^9.0.0-beta.9",
     "maplibre-gl": "^3.5.2"
   }
 }

--- a/custom-markers/package.json
+++ b/custom-markers/package.json
@@ -14,14 +14,14 @@
     "vite": "^4.5.0"
   },
   "dependencies": {
-    "@deck.gl/google-maps": "^9.0.0-beta.1",
-    "@deck.gl/aggregation-layers": "^9.0.0-beta.1",
-    "@deck.gl/carto": "^9.0.0-beta.1",
-    "@deck.gl/core": "^9.0.0-beta.1",
-    "@deck.gl/extensions": "^9.0.0-beta.1",
-    "@deck.gl/geo-layers": "^9.0.0-beta.1",
-    "@deck.gl/layers": "^9.0.0-beta.1",
-    "@deck.gl/mesh-layers": "^9.0.0-beta.1",
+    "@deck.gl/google-maps": "^9.0.0-beta.9",
+    "@deck.gl/aggregation-layers": "^9.0.0-beta.9",
+    "@deck.gl/carto": "^9.0.0-beta.9",
+    "@deck.gl/core": "^9.0.0-beta.9",
+    "@deck.gl/extensions": "^9.0.0-beta.9",
+    "@deck.gl/geo-layers": "^9.0.0-beta.9",
+    "@deck.gl/layers": "^9.0.0-beta.9",
+    "@deck.gl/mesh-layers": "^9.0.0-beta.9",
     "maplibre-gl": "^3.5.2"
   }
 }

--- a/dynamic-tiling-pois/package.json
+++ b/dynamic-tiling-pois/package.json
@@ -14,13 +14,13 @@
     "vite": "^4.5.0"
   },
   "dependencies": {
-    "@deck.gl/aggregation-layers": "^9.0.0-beta.1",
-    "@deck.gl/carto": "^9.0.0-beta.1",
-    "@deck.gl/core": "^9.0.0-beta.1",
-    "@deck.gl/extensions": "^9.0.0-beta.1",
-    "@deck.gl/geo-layers": "^9.0.0-beta.1",
-    "@deck.gl/layers": "^9.0.0-beta.1",
-    "@deck.gl/mesh-layers": "^9.0.0-beta.1",
+    "@deck.gl/aggregation-layers": "^9.0.0-beta.9",
+    "@deck.gl/carto": "^9.0.0-beta.9",
+    "@deck.gl/core": "^9.0.0-beta.9",
+    "@deck.gl/extensions": "^9.0.0-beta.9",
+    "@deck.gl/geo-layers": "^9.0.0-beta.9",
+    "@deck.gl/layers": "^9.0.0-beta.9",
+    "@deck.gl/mesh-layers": "^9.0.0-beta.9",
     "maplibre-gl": "^3.5.2"
   }
 }

--- a/globe-view/package.json
+++ b/globe-view/package.json
@@ -14,13 +14,13 @@
     "vite": "^4.5.0"
   },
   "dependencies": {
-    "@deck.gl/aggregation-layers": "^9.0.0-alpha.5",
-    "@deck.gl/carto": "^9.0.0-alpha.5",
-    "@deck.gl/core": "^9.0.0-alpha.5",
-    "@deck.gl/extensions": "^9.0.0-alpha.5",
-    "@deck.gl/geo-layers": "^9.0.0-alpha.5",
-    "@deck.gl/layers": "^9.0.0-alpha.5",
-    "@deck.gl/mesh-layers": "^9.0.0-alpha.5",
+    "@deck.gl/aggregation-layers": "^9.0.0-beta.9",
+    "@deck.gl/carto": "^9.0.0-beta.9",
+    "@deck.gl/core": "^9.0.0-beta.9",
+    "@deck.gl/extensions": "^9.0.0-beta.9",
+    "@deck.gl/geo-layers": "^9.0.0-beta.9",
+    "@deck.gl/layers": "^9.0.0-beta.9",
+    "@deck.gl/mesh-layers": "^9.0.0-beta.9",
     "maplibre-gl": "^3.5.2"
   }
 }

--- a/google-basemap/package.json
+++ b/google-basemap/package.json
@@ -13,15 +13,15 @@
     "vite": "^4.5.0"
   },
   "dependencies": {
-    "@deck.gl/google-maps": "^9.0.0-beta.1",
+    "@deck.gl/google-maps": "^9.0.0-beta.9",
     "@googlemaps/js-api-loader": "^1.16.2",
-    "@deck.gl/aggregation-layers": "^9.0.0-beta.1",
-    "@deck.gl/carto": "^9.0.0-beta.1",
-    "@deck.gl/core": "^9.0.0-beta.1",
-    "@deck.gl/extensions": "^9.0.0-beta.1",
-    "@deck.gl/geo-layers": "^9.0.0-beta.1",
-    "@deck.gl/layers": "^9.0.0-beta.1",
-    "@deck.gl/mesh-layers": "^9.0.0-beta.1",
+    "@deck.gl/aggregation-layers": "^9.0.0-beta.9",
+    "@deck.gl/carto": "^9.0.0-beta.9",
+    "@deck.gl/core": "^9.0.0-beta.9",
+    "@deck.gl/extensions": "^9.0.0-beta.9",
+    "@deck.gl/geo-layers": "^9.0.0-beta.9",
+    "@deck.gl/layers": "^9.0.0-beta.9",
+    "@deck.gl/mesh-layers": "^9.0.0-beta.9",
     "maplibre-gl": "^3.5.2"
   }
 }

--- a/hello-world/package.json
+++ b/hello-world/package.json
@@ -15,13 +15,13 @@
     "vite": "^4.5.0"
   },
   "dependencies": {
-    "@deck.gl/aggregation-layers": "^9.0.0-beta.1",
-    "@deck.gl/carto": "^9.0.0-beta.1",
-    "@deck.gl/core": "^9.0.0-beta.1",
-    "@deck.gl/extensions": "^9.0.0-beta.1",
-    "@deck.gl/geo-layers": "^9.0.0-beta.1",
-    "@deck.gl/layers": "^9.0.0-beta.1",
-    "@deck.gl/mesh-layers": "^9.0.0-beta.1",
+    "@deck.gl/aggregation-layers": "^9.0.0-beta.9",
+    "@deck.gl/carto": "^9.0.0-beta.9",
+    "@deck.gl/core": "^9.0.0-beta.9",
+    "@deck.gl/extensions": "^9.0.0-beta.9",
+    "@deck.gl/geo-layers": "^9.0.0-beta.9",
+    "@deck.gl/layers": "^9.0.0-beta.9",
+    "@deck.gl/mesh-layers": "^9.0.0-beta.9",
     "@types/react": "^18.2.37",
     "maplibre-gl": "^3.5.2",
     "react": "^18.2.0"

--- a/labels/package.json
+++ b/labels/package.json
@@ -14,13 +14,13 @@
     "vite": "^4.5.0"
   },
   "dependencies": {
-    "@deck.gl/aggregation-layers": "^9.0.0-beta.1",
-    "@deck.gl/carto": "^9.0.0-beta.1",
-    "@deck.gl/core": "^9.0.0-beta.1",
-    "@deck.gl/extensions": "^9.0.0-beta.1",
-    "@deck.gl/geo-layers": "^9.0.0-beta.1",
-    "@deck.gl/layers": "^9.0.0-beta.1",
-    "@deck.gl/mesh-layers": "^9.0.0-beta.1",
+    "@deck.gl/aggregation-layers": "^9.0.0-beta.9",
+    "@deck.gl/carto": "^9.0.0-beta.9",
+    "@deck.gl/core": "^9.0.0-beta.9",
+    "@deck.gl/extensions": "^9.0.0-beta.9",
+    "@deck.gl/geo-layers": "^9.0.0-beta.9",
+    "@deck.gl/layers": "^9.0.0-beta.9",
+    "@deck.gl/mesh-layers": "^9.0.0-beta.9",
     "maplibre-gl": "^3.5.2",
     "d3-scale": "^2.0.0"
   }

--- a/query-accidents/package.json
+++ b/query-accidents/package.json
@@ -14,13 +14,13 @@
     "vite": "^4.5.0"
   },
   "dependencies": {
-    "@deck.gl/aggregation-layers": "^9.0.0-beta.1",
-    "@deck.gl/carto": "^9.0.0-beta.1",
-    "@deck.gl/core": "^9.0.0-beta.1",
-    "@deck.gl/extensions": "^9.0.0-beta.1",
-    "@deck.gl/geo-layers": "^9.0.0-beta.1",
-    "@deck.gl/layers": "^9.0.0-beta.1",
-    "@deck.gl/mesh-layers": "^9.0.0-beta.1",
+    "@deck.gl/aggregation-layers": "^9.0.0-beta.9",
+    "@deck.gl/carto": "^9.0.0-beta.9",
+    "@deck.gl/core": "^9.0.0-beta.9",
+    "@deck.gl/extensions": "^9.0.0-beta.9",
+    "@deck.gl/geo-layers": "^9.0.0-beta.9",
+    "@deck.gl/layers": "^9.0.0-beta.9",
+    "@deck.gl/mesh-layers": "^9.0.0-beta.9",
     "maplibre-gl": "^3.5.2"
   }
 }

--- a/raster-temperature/index.ts
+++ b/raster-temperature/index.ts
@@ -14,12 +14,12 @@ const INITIAL_VIEW_STATE = {
   longitude: 14.4378,
   zoom: 12,
   bearing: 0,
-  pitch: 0,
+  pitch: 0
 };
 
 const dataSource = rasterSource({
   ...cartoConfig,
-  tableName: 'cartobq.public_account.temperature_raster_int8_new',
+  tableName: 'cartobq.public_account.temperature_raster_int8_new'
 });
 
 const deck = new Deck({
@@ -30,9 +30,7 @@ const deck = new Deck({
     new RasterTileLayer({
       id: 'temperature',
       data: dataSource,
-      // getFillColor: [255, 0, 0],
       getFillColor: d => {
-        console.log(d.properties)
         const {band_1} = d.properties;
         return [10 * (band_1 - 20), 0, 300 - 5 * band_1];
       }

--- a/raster-temperature/package.json
+++ b/raster-temperature/package.json
@@ -14,13 +14,13 @@
     "vite": "^4.5.0"
   },
   "dependencies": {
-    "@deck.gl/aggregation-layers": "^9.0.0-beta.1",
-    "@deck.gl/carto": "^9.0.0-beta.1",
-    "@deck.gl/core": "^9.0.0-beta.1",
-    "@deck.gl/extensions": "^9.0.0-beta.1",
-    "@deck.gl/geo-layers": "^9.0.0-beta.1",
-    "@deck.gl/layers": "^9.0.0-beta.1",
-    "@deck.gl/mesh-layers": "^9.0.0-beta.1",
+    "@deck.gl/aggregation-layers": "^9.0.0-beta.9",
+    "@deck.gl/carto": "^9.0.0-beta.9",
+    "@deck.gl/core": "^9.0.0-beta.9",
+    "@deck.gl/extensions": "^9.0.0-beta.9",
+    "@deck.gl/geo-layers": "^9.0.0-beta.9",
+    "@deck.gl/layers": "^9.0.0-beta.9",
+    "@deck.gl/mesh-layers": "^9.0.0-beta.9",
     "maplibre-gl": "^3.5.2"
   }
 }

--- a/spatial-features-h3/package.json
+++ b/spatial-features-h3/package.json
@@ -14,13 +14,13 @@
     "vite": "^4.5.0"
   },
   "dependencies": {
-    "@deck.gl/aggregation-layers": "^9.0.0-beta.1",
-    "@deck.gl/carto": "^9.0.0-beta.1",
-    "@deck.gl/core": "^9.0.0-beta.1",
-    "@deck.gl/extensions": "^9.0.0-beta.1",
-    "@deck.gl/geo-layers": "^9.0.0-beta.1",
-    "@deck.gl/layers": "^9.0.0-beta.1",
-    "@deck.gl/mesh-layers": "^9.0.0-beta.1",
+    "@deck.gl/aggregation-layers": "^9.0.0-beta.9",
+    "@deck.gl/carto": "^9.0.0-beta.9",
+    "@deck.gl/core": "^9.0.0-beta.9",
+    "@deck.gl/extensions": "^9.0.0-beta.9",
+    "@deck.gl/geo-layers": "^9.0.0-beta.9",
+    "@deck.gl/layers": "^9.0.0-beta.9",
+    "@deck.gl/mesh-layers": "^9.0.0-beta.9",
     "maplibre-gl": "^3.5.2"
   }
 }

--- a/spatial-features-quadbin/package.json
+++ b/spatial-features-quadbin/package.json
@@ -14,13 +14,13 @@
     "vite": "^4.5.0"
   },
   "dependencies": {
-    "@deck.gl/aggregation-layers": "^9.0.0-beta.1",
-    "@deck.gl/carto": "^9.0.0-beta.1",
-    "@deck.gl/core": "^9.0.0-beta.1",
-    "@deck.gl/extensions": "^9.0.0-beta.1",
-    "@deck.gl/geo-layers": "^9.0.0-beta.1",
-    "@deck.gl/layers": "^9.0.0-beta.1",
-    "@deck.gl/mesh-layers": "^9.0.0-beta.1",
+    "@deck.gl/aggregation-layers": "^9.0.0-beta.9",
+    "@deck.gl/carto": "^9.0.0-beta.9",
+    "@deck.gl/core": "^9.0.0-beta.9",
+    "@deck.gl/extensions": "^9.0.0-beta.9",
+    "@deck.gl/geo-layers": "^9.0.0-beta.9",
+    "@deck.gl/layers": "^9.0.0-beta.9",
+    "@deck.gl/mesh-layers": "^9.0.0-beta.9",
     "maplibre-gl": "^3.5.2"
   }
 }

--- a/tileset-buildings/package.json
+++ b/tileset-buildings/package.json
@@ -14,13 +14,13 @@
     "vite": "^4.5.0"
   },
   "dependencies": {
-    "@deck.gl/aggregation-layers": "^9.0.0-beta.1",
-    "@deck.gl/carto": "^9.0.0-beta.1",
-    "@deck.gl/core": "^9.0.0-beta.1",
-    "@deck.gl/extensions": "^9.0.0-beta.1",
-    "@deck.gl/geo-layers": "^9.0.0-beta.1",
-    "@deck.gl/layers": "^9.0.0-beta.1",
-    "@deck.gl/mesh-layers": "^9.0.0-beta.1",
+    "@deck.gl/aggregation-layers": "^9.0.0-beta.9",
+    "@deck.gl/carto": "^9.0.0-beta.9",
+    "@deck.gl/core": "^9.0.0-beta.9",
+    "@deck.gl/extensions": "^9.0.0-beta.9",
+    "@deck.gl/geo-layers": "^9.0.0-beta.9",
+    "@deck.gl/layers": "^9.0.0-beta.9",
+    "@deck.gl/mesh-layers": "^9.0.0-beta.9",
     "maplibre-gl": "^3.5.2"
   }
 }

--- a/trips/package.json
+++ b/trips/package.json
@@ -14,13 +14,13 @@
     "vite": "^4.5.0"
   },
   "dependencies": {
-    "@deck.gl/aggregation-layers": "^9.0.0-beta.1",
-    "@deck.gl/carto": "^9.0.0-beta.1",
-    "@deck.gl/core": "^9.0.0-beta.1",
-    "@deck.gl/extensions": "^9.0.0-beta.1",
-    "@deck.gl/geo-layers": "^9.0.0-beta.1",
-    "@deck.gl/layers": "^9.0.0-beta.1",
-    "@deck.gl/mesh-layers": "^9.0.0-beta.1",
+    "@deck.gl/aggregation-layers": "^9.0.0-beta.9",
+    "@deck.gl/carto": "^9.0.0-beta.9",
+    "@deck.gl/core": "^9.0.0-beta.9",
+    "@deck.gl/extensions": "^9.0.0-beta.9",
+    "@deck.gl/geo-layers": "^9.0.0-beta.9",
+    "@deck.gl/layers": "^9.0.0-beta.9",
+    "@deck.gl/mesh-layers": "^9.0.0-beta.9",
     "maplibre-gl": "^3.5.2"
   }
 }


### PR DESCRIPTION
I've gone through all the examples and they work great, except for the raster layer, but this will be fixed in deck