### PR TITLE
chore: bump deckgl version (removes beta)

### DIFF
--- a/amazon-locations/package.json
+++ b/amazon-locations/package.json
@@ -14,13 +14,13 @@
     "vite": "^4.5.0"
   },
   "dependencies": {
-    "@deck.gl/aggregation-layers": "^9.0.0-beta.9",
-    "@deck.gl/carto": "^9.0.0-beta.9",
-    "@deck.gl/core": "^9.0.0-beta.9",
-    "@deck.gl/extensions": "^9.0.0-beta.9",
-    "@deck.gl/geo-layers": "^9.0.0-beta.9",
-    "@deck.gl/layers": "^9.0.0-beta.9",
-    "@deck.gl/mesh-layers": "^9.0.0-beta.9",
+    "@deck.gl/aggregation-layers": "^9.0.17",
+    "@deck.gl/carto": "^9.0.17",
+    "@deck.gl/core": "^9.0.17",
+    "@deck.gl/extensions": "^9.0.17",
+    "@deck.gl/geo-layers": "^9.0.17",
+    "@deck.gl/layers": "^9.0.17",
+    "@deck.gl/mesh-layers": "^9.0.17",
     "maplibre-gl": "^3.5.2"
   }
 }

--- a/boundaries/package.json
+++ b/boundaries/package.json
@@ -14,13 +14,13 @@
     "vite": "^4.5.0"
   },
   "dependencies": {
-    "@deck.gl/aggregation-layers": "^9.0.0-beta.9",
-    "@deck.gl/carto": "^9.0.0-beta.9",
-    "@deck.gl/core": "^9.0.0-beta.9",
-    "@deck.gl/extensions": "^9.0.0-beta.9",
-    "@deck.gl/geo-layers": "^9.0.0-beta.9",
-    "@deck.gl/layers": "^9.0.0-beta.9",
-    "@deck.gl/mesh-layers": "^9.0.0-beta.9",
+    "@deck.gl/aggregation-layers": "^9.0.17",
+    "@deck.gl/carto": "^9.0.17",
+    "@deck.gl/core": "^9.0.17",
+    "@deck.gl/extensions": "^9.0.17",
+    "@deck.gl/geo-layers": "^9.0.17",
+    "@deck.gl/layers": "^9.0.17",
+    "@deck.gl/mesh-layers": "^9.0.17",
     "maplibre-gl": "^3.5.2"
   }
 }

--- a/carto-colors/package.json
+++ b/carto-colors/package.json
@@ -14,13 +14,13 @@
     "vite": "^4.5.0"
   },
   "dependencies": {
-    "@deck.gl/aggregation-layers": "^9.0.0-beta.9",
-    "@deck.gl/carto": "^9.0.0-beta.9",
-    "@deck.gl/core": "^9.0.0-beta.9",
-    "@deck.gl/extensions": "^9.0.0-beta.9",
-    "@deck.gl/geo-layers": "^9.0.0-beta.9",
-    "@deck.gl/layers": "^9.0.0-beta.9",
-    "@deck.gl/mesh-layers": "^9.0.0-beta.9",
+    "@deck.gl/aggregation-layers": "^9.0.17",
+    "@deck.gl/carto": "^9.0.17",
+    "@deck.gl/core": "^9.0.17",
+    "@deck.gl/extensions": "^9.0.17",
+    "@deck.gl/geo-layers": "^9.0.17",
+    "@deck.gl/layers": "^9.0.17",
+    "@deck.gl/mesh-layers": "^9.0.17",
     "maplibre-gl": "^3.5.2"
   }
 }

--- a/custom-markers/package.json
+++ b/custom-markers/package.json
@@ -14,14 +14,14 @@
     "vite": "^4.5.0"
   },
   "dependencies": {
-    "@deck.gl/google-maps": "^9.0.0-beta.9",
-    "@deck.gl/aggregation-layers": "^9.0.0-beta.9",
-    "@deck.gl/carto": "^9.0.0-beta.9",
-    "@deck.gl/core": "^9.0.0-beta.9",
-    "@deck.gl/extensions": "^9.0.0-beta.9",
-    "@deck.gl/geo-layers": "^9.0.0-beta.9",
-    "@deck.gl/layers": "^9.0.0-beta.9",
-    "@deck.gl/mesh-layers": "^9.0.0-beta.9",
+    "@deck.gl/google-maps": "^9.0.17",
+    "@deck.gl/aggregation-layers": "^9.0.17",
+    "@deck.gl/carto": "^9.0.17",
+    "@deck.gl/core": "^9.0.17",
+    "@deck.gl/extensions": "^9.0.17",
+    "@deck.gl/geo-layers": "^9.0.17",
+    "@deck.gl/layers": "^9.0.17",
+    "@deck.gl/mesh-layers": "^9.0.17",
     "maplibre-gl": "^3.5.2"
   }
 }

--- a/dynamic-tiling-pois/package.json
+++ b/dynamic-tiling-pois/package.json
@@ -14,13 +14,13 @@
     "vite": "^4.5.0"
   },
   "dependencies": {
-    "@deck.gl/aggregation-layers": "^9.0.0-beta.9",
-    "@deck.gl/carto": "^9.0.0-beta.9",
-    "@deck.gl/core": "^9.0.0-beta.9",
-    "@deck.gl/extensions": "^9.0.0-beta.9",
-    "@deck.gl/geo-layers": "^9.0.0-beta.9",
-    "@deck.gl/layers": "^9.0.0-beta.9",
-    "@deck.gl/mesh-layers": "^9.0.0-beta.9",
+    "@deck.gl/aggregation-layers": "^9.0.17",
+    "@deck.gl/carto": "^9.0.17",
+    "@deck.gl/core": "^9.0.17",
+    "@deck.gl/extensions": "^9.0.17",
+    "@deck.gl/geo-layers": "^9.0.17",
+    "@deck.gl/layers": "^9.0.17",
+    "@deck.gl/mesh-layers": "^9.0.17",
     "maplibre-gl": "^3.5.2"
   }
 }

--- a/globe-view/package.json
+++ b/globe-view/package.json
@@ -14,13 +14,13 @@
     "vite": "^4.5.0"
   },
   "dependencies": {
-    "@deck.gl/aggregation-layers": "^9.0.0-beta.9",
-    "@deck.gl/carto": "^9.0.0-beta.9",
-    "@deck.gl/core": "^9.0.0-beta.9",
-    "@deck.gl/extensions": "^9.0.0-beta.9",
-    "@deck.gl/geo-layers": "^9.0.0-beta.9",
-    "@deck.gl/layers": "^9.0.0-beta.9",
-    "@deck.gl/mesh-layers": "^9.0.0-beta.9",
+    "@deck.gl/aggregation-layers": "^9.0.17",
+    "@deck.gl/carto": "^9.0.17",
+    "@deck.gl/core": "^9.0.17",
+    "@deck.gl/extensions": "^9.0.17",
+    "@deck.gl/geo-layers": "^9.0.17",
+    "@deck.gl/layers": "^9.0.17",
+    "@deck.gl/mesh-layers": "^9.0.17",
     "maplibre-gl": "^3.5.2"
   }
 }

--- a/google-basemap/package.json
+++ b/google-basemap/package.json
@@ -13,15 +13,15 @@
     "vite": "^4.5.0"
   },
   "dependencies": {
-    "@deck.gl/google-maps": "^9.0.0-beta.9",
+    "@deck.gl/google-maps": "^9.0.17",
     "@googlemaps/js-api-loader": "^1.16.2",
-    "@deck.gl/aggregation-layers": "^9.0.0-beta.9",
-    "@deck.gl/carto": "^9.0.0-beta.9",
-    "@deck.gl/core": "^9.0.0-beta.9",
-    "@deck.gl/extensions": "^9.0.0-beta.9",
-    "@deck.gl/geo-layers": "^9.0.0-beta.9",
-    "@deck.gl/layers": "^9.0.0-beta.9",
-    "@deck.gl/mesh-layers": "^9.0.0-beta.9",
+    "@deck.gl/aggregation-layers": "^9.0.17",
+    "@deck.gl/carto": "^9.0.17",
+    "@deck.gl/core": "^9.0.17",
+    "@deck.gl/extensions": "^9.0.17",
+    "@deck.gl/geo-layers": "^9.0.17",
+    "@deck.gl/layers": "^9.0.17",
+    "@deck.gl/mesh-layers": "^9.0.17",
     "maplibre-gl": "^3.5.2"
   }
 }

--- a/hello-world/package.json
+++ b/hello-world/package.json
@@ -15,13 +15,13 @@
     "vite": "^4.5.0"
   },
   "dependencies": {
-    "@deck.gl/aggregation-layers": "^9.0.0-beta.9",
-    "@deck.gl/carto": "^9.0.0-beta.9",
-    "@deck.gl/core": "^9.0.0-beta.9",
-    "@deck.gl/extensions": "^9.0.0-beta.9",
-    "@deck.gl/geo-layers": "^9.0.0-beta.9",
-    "@deck.gl/layers": "^9.0.0-beta.9",
-    "@deck.gl/mesh-layers": "^9.0.0-beta.9",
+    "@deck.gl/aggregation-layers": "^9.0.17",
+    "@deck.gl/carto": "^9.0.17",
+    "@deck.gl/core": "^9.0.17",
+    "@deck.gl/extensions": "^9.0.17",
+    "@deck.gl/geo-layers": "^9.0.17",
+    "@deck.gl/layers": "^9.0.17",
+    "@deck.gl/mesh-layers": "^9.0.17",
     "@types/react": "^18.2.37",
     "maplibre-gl": "^3.5.2",
     "react": "^18.2.0"

--- a/labels/package.json
+++ b/labels/package.json
@@ -14,13 +14,13 @@
     "vite": "^4.5.0"
   },
   "dependencies": {
-    "@deck.gl/aggregation-layers": "^9.0.0-beta.9",
-    "@deck.gl/carto": "^9.0.0-beta.9",
-    "@deck.gl/core": "^9.0.0-beta.9",
-    "@deck.gl/extensions": "^9.0.0-beta.9",
-    "@deck.gl/geo-layers": "^9.0.0-beta.9",
-    "@deck.gl/layers": "^9.0.0-beta.9",
-    "@deck.gl/mesh-layers": "^9.0.0-beta.9",
+    "@deck.gl/aggregation-layers": "^9.0.17",
+    "@deck.gl/carto": "^9.0.17",
+    "@deck.gl/core": "^9.0.17",
+    "@deck.gl/extensions": "^9.0.17",
+    "@deck.gl/geo-layers": "^9.0.17",
+    "@deck.gl/layers": "^9.0.17",
+    "@deck.gl/mesh-layers": "^9.0.17",
     "maplibre-gl": "^3.5.2",
     "d3-scale": "^2.0.0"
   }

--- a/query-accidents/package.json
+++ b/query-accidents/package.json
@@ -14,13 +14,13 @@
     "vite": "^4.5.0"
   },
   "dependencies": {
-    "@deck.gl/aggregation-layers": "^9.0.0-beta.9",
-    "@deck.gl/carto": "^9.0.0-beta.9",
-    "@deck.gl/core": "^9.0.0-beta.9",
-    "@deck.gl/extensions": "^9.0.0-beta.9",
-    "@deck.gl/geo-layers": "^9.0.0-beta.9",
-    "@deck.gl/layers": "^9.0.0-beta.9",
-    "@deck.gl/mesh-layers": "^9.0.0-beta.9",
+    "@deck.gl/aggregation-layers": "^9.0.17",
+    "@deck.gl/carto": "^9.0.17",
+    "@deck.gl/core": "^9.0.17",
+    "@deck.gl/extensions": "^9.0.17",
+    "@deck.gl/geo-layers": "^9.0.17",
+    "@deck.gl/layers": "^9.0.17",
+    "@deck.gl/mesh-layers": "^9.0.17",
     "maplibre-gl": "^3.5.2"
   }
 }

--- a/raster-temperature/package.json
+++ b/raster-temperature/package.json
@@ -14,13 +14,13 @@
     "vite": "^4.5.0"
   },
   "dependencies": {
-    "@deck.gl/aggregation-layers": "^9.0.0-beta.9",
-    "@deck.gl/carto": "^9.0.0-beta.9",
-    "@deck.gl/core": "^9.0.0-beta.9",
-    "@deck.gl/extensions": "^9.0.0-beta.9",
-    "@deck.gl/geo-layers": "^9.0.0-beta.9",
-    "@deck.gl/layers": "^9.0.0-beta.9",
-    "@deck.gl/mesh-layers": "^9.0.0-beta.9",
+    "@deck.gl/aggregation-layers": "^9.0.17",
+    "@deck.gl/carto": "^9.0.17",
+    "@deck.gl/core": "^9.0.17",
+    "@deck.gl/extensions": "^9.0.17",
+    "@deck.gl/geo-layers": "^9.0.17",
+    "@deck.gl/layers": "^9.0.17",
+    "@deck.gl/mesh-layers": "^9.0.17",
     "maplibre-gl": "^3.5.2"
   }
 }

--- a/spatial-features-h3/package.json
+++ b/spatial-features-h3/package.json
@@ -14,13 +14,13 @@
     "vite": "^4.5.0"
   },
   "dependencies": {
-    "@deck.gl/aggregation-layers": "^9.0.0-beta.9",
-    "@deck.gl/carto": "^9.0.0-beta.9",
-    "@deck.gl/core": "^9.0.0-beta.9",
-    "@deck.gl/extensions": "^9.0.0-beta.9",
-    "@deck.gl/geo-layers": "^9.0.0-beta.9",
-    "@deck.gl/layers": "^9.0.0-beta.9",
-    "@deck.gl/mesh-layers": "^9.0.0-beta.9",
+    "@deck.gl/aggregation-layers": "^9.0.17",
+    "@deck.gl/carto": "^9.0.17",
+    "@deck.gl/core": "^9.0.17",
+    "@deck.gl/extensions": "^9.0.17",
+    "@deck.gl/geo-layers": "^9.0.17",
+    "@deck.gl/layers": "^9.0.17",
+    "@deck.gl/mesh-layers": "^9.0.17",
     "maplibre-gl": "^3.5.2"
   }
 }

--- a/spatial-features-quadbin/package.json
+++ b/spatial-features-quadbin/package.json
@@ -14,13 +14,13 @@
     "vite": "^4.5.0"
   },
   "dependencies": {
-    "@deck.gl/aggregation-layers": "^9.0.0-beta.9",
-    "@deck.gl/carto": "^9.0.0-beta.9",
-    "@deck.gl/core": "^9.0.0-beta.9",
-    "@deck.gl/extensions": "^9.0.0-beta.9",
-    "@deck.gl/geo-layers": "^9.0.0-beta.9",
-    "@deck.gl/layers": "^9.0.0-beta.9",
-    "@deck.gl/mesh-layers": "^9.0.0-beta.9",
+    "@deck.gl/aggregation-layers": "^9.0.17",
+    "@deck.gl/carto": "^9.0.17",
+    "@deck.gl/core": "^9.0.17",
+    "@deck.gl/extensions": "^9.0.17",
+    "@deck.gl/geo-layers": "^9.0.17",
+    "@deck.gl/layers": "^9.0.17",
+    "@deck.gl/mesh-layers": "^9.0.17",
     "maplibre-gl": "^3.5.2"
   }
 }

--- a/tileset-buildings/package.json
+++ b/tileset-buildings/package.json
@@ -14,13 +14,13 @@
     "vite": "^4.5.0"
   },
   "dependencies": {
-    "@deck.gl/aggregation-layers": "^9.0.0-beta.9",
-    "@deck.gl/carto": "^9.0.0-beta.9",
-    "@deck.gl/core": "^9.0.0-beta.9",
-    "@deck.gl/extensions": "^9.0.0-beta.9",
-    "@deck.gl/geo-layers": "^9.0.0-beta.9",
-    "@deck.gl/layers": "^9.0.0-beta.9",
-    "@deck.gl/mesh-layers": "^9.0.0-beta.9",
+    "@deck.gl/aggregation-layers": "^9.0.17",
+    "@deck.gl/carto": "^9.0.17",
+    "@deck.gl/core": "^9.0.17",
+    "@deck.gl/extensions": "^9.0.17",
+    "@deck.gl/geo-layers": "^9.0.17",
+    "@deck.gl/layers": "^9.0.17",
+    "@deck.gl/mesh-layers": "^9.0.17",
     "maplibre-gl": "^3.5.2"
   }
 }

--- a/trips/package.json
+++ b/trips/package.json
@@ -14,13 +14,13 @@
     "vite": "^4.5.0"
   },
   "dependencies": {
-    "@deck.gl/aggregation-layers": "^9.0.0-beta.9",
-    "@deck.gl/carto": "^9.0.0-beta.9",
-    "@deck.gl/core": "^9.0.0-beta.9",
-    "@deck.gl/extensions": "^9.0.0-beta.9",
-    "@deck.gl/geo-layers": "^9.0.0-beta.9",
-    "@deck.gl/layers": "^9.0.0-beta.9",
-    "@deck.gl/mesh-layers": "^9.0.0-beta.9",
+    "@deck.gl/aggregation-layers": "^9.0.17",
+    "@deck.gl/carto": "^9.0.17",
+    "@deck.gl/core": "^9.0.17",
+    "@deck.gl/extensions": "^9.0.17",
+    "@deck.gl/geo-layers": "^9.0.17",
+    "@deck.gl/layers": "^9.0.17",
+    "@deck.gl/mesh-layers": "^9.0.17",
     "maplibre-gl": "^3.5.2"
   }
 }


### PR DESCRIPTION
As reported by Support, we were still using the beta versions in this repository.

@felixpalmer @donmccurdy not sure if you'd want a specific version other than `^9.0.17`