### PR TITLE
New named sources example

### DIFF
--- a/named-sources/.env
+++ b/named-sources/.env
@@ -1,0 +1,7 @@
+# API Base URL (copy this from CARTO Workspace -> Developers)
+VITE_API_BASE_URL=https://gcp-us-east1.api.carto.com
+
+# This API Access Token only grants access to demo data for the examples. Replace it with your own token.
+# Go to app.carto.com -> Developers -> Credentials -> API Access Tokens.
+VITE_API_ACCESS_TOKEN=eyJhbGciOiJIUzI1NiJ9.eyJhIjoiYWNfbHFlM3p3Z3UiLCJqdGkiOiJkOTU4OWMyZiJ9.78MdzU2J6y-J6Far71_Mh7IQO9eYIZD9nECUiZJAVL4
+

--- a/named-sources/README.md
+++ b/named-sources/README.md
@@ -1,0 +1,24 @@
+## Example: SQL Named Sources (Accidents by State)
+
+This example is similar to the [query-accidents](../query-accidents/) example, but it leverages CARTO [Named Sources](https://docs.carto.com/carto-user-manual/developers/named-sources) instead of directly using SQL queries in the application.
+
+By using Named Sources, we prevent SQL queries from being exposed in the code or the network requests made by the application, reducing the surface for attacks and hiding the business logic in our application. The architecture of the application is still lightweight, efficient and modern, and there is no performance or overhead by using Named Sources.
+
+Uses [Vite](https://vitejs.dev/) to bundle and serve files.
+
+## Usage
+
+[![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/CartoDB/deck.gl-examples/tree/master/sql-named-sources?file=index.ts)
+
+Or run it locally:
+
+```bash
+npm install
+# or
+yarn
+```
+
+Commands:
+
+- `npm dev` is the development target, to serve the app and hot reload.
+- `npm run build` is the production target, to create the final bundle and write to disk.

--- a/named-sources/index.html
+++ b/named-sources/index.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link
+      rel="icon"
+      type="image/png"
+      sizes="32x32"
+      href="https://app.carto.com/favicon/favicon-32x32.png"
+    />
+    <link
+      rel="icon"
+      type="image/png"
+      sizes="16x16"
+      href="https://app.carto.com/favicon/favicon-16x16.png"
+    />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&display=swap"
+      rel="stylesheet"
+    />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>CARTO + deck.gl - Using Named Sources to prevent exposing SQL queries </title>
+  <body>
+    <div id="app">
+      <div id="map"></div>
+      <canvas id="deck-canvas"></canvas>
+      <div id="story-card">
+        <p class="overline">✨👀 You're viewing</p>
+        <h2>SQL Named Sources</h2>
+        <p>This application still uses SQL queries under the hood, but they are not exposed thanks to Named Sources.</p>
+        <p>Named sources provide a mechanism to completely remove SQL queries from your application code and from all API requests, using references instead.</p>
+        <p>Learn more about <a href="https://docs.carto.com/carto-user-manual/developers/named-sources">Named sources in the CARTO documentation</a>.</p>
+        <div class="layer-controls"> 
+          <p class="overline">Choose a year to filter accidents</p>
+          <select id="yearSelector">
+            <option value="2010">2010</option>
+            <option value="2011">2011</option>
+            <option value="2012">2012</option>
+            <option value="2013" selected>2013</option>
+          </select>
+          <p class="caption source">Source: U.S. DOT Federal Railway Administration</p>
+        </div>
+      </div>
+    </div>
+    <script type="module" src="./index.ts"></script>
+  </body>
+</html>

--- a/named-sources/index.ts
+++ b/named-sources/index.ts
@@ -61,7 +61,6 @@ function render() {
     new VectorTileLayer({
       id: 'accidents_by_state',
       data: accidentsByState,
-      pickable: true,
       opacity: 0.8,
       getFillColor: colorBins({
         attr: 'count',

--- a/named-sources/index.ts
+++ b/named-sources/index.ts
@@ -1,0 +1,92 @@
+import './style.css';
+import maplibregl from 'maplibre-gl';
+import 'maplibre-gl/dist/maplibre-gl.css';
+import {Deck} from '@deck.gl/core';
+import {BASEMAP, vectorQuerySource, VectorTileLayer, colorBins} from '@deck.gl/carto';
+
+const apiBaseUrl = import.meta.env.VITE_API_BASE_URL;
+const accessToken = import.meta.env.VITE_API_ACCESS_TOKEN;
+const connectionName = 'carto_dw';
+const cartoConfig = {apiBaseUrl, accessToken, connectionName};
+
+const INITIAL_VIEW_STATE = {
+  latitude: 41.8097343,
+  longitude: -110.5556199,
+  zoom: 3,
+  bearing: 0,
+  pitch: 0
+};
+
+const deck = new Deck({
+  canvas: 'deck-canvas',
+  initialViewState: INITIAL_VIEW_STATE,
+  controller: true
+});
+
+// Add basemap
+const map = new maplibregl.Map({
+  container: 'map',
+  style: BASEMAP.DARK_MATTER,
+  interactive: false
+});
+
+deck.setProps({
+  onViewStateChange: ({viewState}) => {
+    const {longitude, latitude, ...rest} = viewState;
+    map.jumpTo({center: [longitude, latitude], ...rest});
+  }
+});
+
+let selectedYear = 2013;
+const selectedYearSelector = document.querySelector<HTMLSelectElement>('#yearSelector');
+selectedYearSelector?.addEventListener('change', () => {
+  selectedYear = Number(selectedYearSelector.value);
+  render();
+});
+
+function render() {
+  const accidentsByState = vectorQuerySource({
+    ...cartoConfig,
+    sqlQuery: 'public_example_accidents_by_state',
+    queryParameters: {selectedYear: selectedYear}
+  });
+
+  const accidents = vectorQuerySource({
+    ...cartoConfig,
+    sqlQuery: 'public_example_accidents',
+    queryParameters: {selectedYear: selectedYear}
+  });
+
+  const layers = [
+    new VectorTileLayer({
+      id: 'accidents_by_state',
+      data: accidentsByState,
+      pickable: true,
+      opacity: 0.8,
+      getFillColor: colorBins({
+        attr: 'count',
+        domain: [0, 10, 30, 60, 100, 200],
+        colors: 'PurpOr'
+      }),
+      getLineColor: [255, 255, 255],
+      lineWidthMinPixels: 1
+    }),
+    new VectorTileLayer({
+      id: 'accidents_prop_symbols',
+      data: accidents,
+      opacity: 0.8,
+      getFillColor: [255, 255, 255],
+      pointRadiusMinPixels: 1,
+      radiusUnits: 'pixels',
+      getPointRadius: (d: any) => {
+        return (d.properties.total_damage + 10) / 100;
+      }
+    })
+  ];
+
+  deck.setProps({
+    layers: layers
+  });
+}
+
+render();

--- a/named-sources/package.json
+++ b/named-sources/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "carto-deckgl-example-sql-named-sources",
+  "version": "0.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "dev-local": "vite --config ../vite.config.local.mjs",
+    "build": "vite build",
+    "preview": "vite preview",
+    "link-deck": "yarn link @deck.gl/core && yarn link @deck.gl/layers && yarn link @deck.gl/geo-layers && yarn link @deck.gl/mesh-layers && yarn link @deck.gl/aggregation-layers && yarn link @deck.gl/carto && yarn link @deck.gl/extensions",
+    "unlink-deck": "yarn unlink @deck.gl/core && yarn link @deck.gl/layers && yarn link @deck.gl/geo-layers && yarn link @deck.gl/mesh-layers && yarn link @deck.gl/aggregation-layers && yarn link @deck.gl/carto && yarn link @deck.gl/extensions"
+  },
+  "devDependencies": {
+    "vite": "^4.5.0"
+  },
+  "dependencies": {
+    "@deck.gl/aggregation-layers": "^9.0.17",
+    "@deck.gl/carto": "^9.0.17",
+    "@deck.gl/core": "^9.0.17",
+    "@deck.gl/extensions": "^9.0.17",
+    "@deck.gl/geo-layers": "^9.0.17",
+    "@deck.gl/layers": "^9.0.17",
+    "@deck.gl/mesh-layers": "^9.0.17",
+    "maplibre-gl": "^3.5.2"
+  }
+}

--- a/named-sources/style.css
+++ b/named-sources/style.css
@@ -1,0 +1,90 @@
+body,
+html {
+  height: 100%;
+  width: 100%;
+  overflow: hidden;
+  position: fixed;
+  font-family: Inter, sans-serif;
+  font-weight: 400;
+  font-size: 1rem;
+  margin: 0;
+}
+
+#map,
+canvas {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  max-height: 100%;
+}
+
+#app {
+  flex: 1 1 auto;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+#story-card {
+  padding: 1.75rem;
+  background: #fdfdfe;
+  box-shadow: 4px 4px 8px #30303099;
+  border-radius: 4px;
+  z-index:1;
+  margin: 1.5rem;
+  max-width: 480px;
+  max-height: 100vh;
+  z-index: 10;
+  overflow: scroll;
+}
+
+.layer-controls {
+  margin-top: 2.25rem;
+}
+
+.overline {
+  font-size: .625rem;
+  font-weight: 600;
+  line-height: 1.2;
+  letter-spacing: .125rem;
+  text-transform: uppercase;
+}
+
+select{
+  margin-bottom: 0.6rem;
+  border-radius: 4px;
+  font-size: 0.8rem;
+  line-height: 1.50;
+  letter-spacing: 0.001rem;
+  max-width: 100%;
+}
+
+select:hover {
+  cursor: pointer;
+}
+
+select {
+  padding: 0.6rem;
+  width: 360px;
+}
+
+.caption {
+  margin-top: 2.25rem;
+  margin-bottom: 0px;
+  font-size: 0.8rem;
+}
+
+.code-block {
+  background: #2C3032;
+  padding: 0.75rem;
+  border-radius: 4px;
+}
+
+.code-block code {
+  font-family: monospace;
+  font-size: 0.75rem;
+  color: white;
+  line-height: 1.25;
+}

--- a/named-sources/tsconfig.json
+++ b/named-sources/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "es2022",
+    "jsx": "react",
+    "strict": true,
+    "noImplicitAny": false,
+    "allowJs": true,
+    "checkJs": false,
+    "moduleResolution": "node",
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "noEmit": true,
+    "resolveJsonModule": true,
+    "skipLibCheck": true,
+    "baseUrl": "."
+  }
+}


### PR DESCRIPTION
Adds a new example for the Named Sources release. It uses the `query-accidents` example as a base, and simply replaces the SQL queries there by named sources to prevent exposing the SQL in the application.

- [x] Updated readme
- [x] Updated code
- [x] Example uses the `public` organization and the right token