### PR TITLE
Fix named sources stackblitz

### DIFF
--- a/named-sources/README.md
+++ b/named-sources/README.md
@@ -8,7 +8,7 @@ Uses [Vite](https://vitejs.dev/) to bundle and serve files.
 
 ## Usage
 
-[![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/CartoDB/deck.gl-examples/tree/master/sql-named-sources?file=index.ts)
+[![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/CartoDB/deck.gl-examples/tree/master/named-sources?file=index.ts)
 
 Or run it locally:
 


### PR DESCRIPTION
Stackblitz link is broken in the example. I only realized about it after merging :)