### PR TITLE
Add warning to all readmes due to Stackblitz dotenv issue

### DIFF
--- a/amazon-locations/README.md
+++ b/amazon-locations/README.md
@@ -1,12 +1,15 @@
 ## Example: Amazon Location Services basemap with CARTO + deck.gl
 
-This example uses a basemap from Amazon Location Services in combination with layers from the CARTO module in deck.gl. 
+This example uses a basemap from Amazon Location Services in combination with layers from the CARTO module in deck.gl.
 
 Uses [Vite](https://vitejs.dev/) to bundle and serve files.
 
 ## Usage
 
 [![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/CartoDB/deck.gl-examples/tree/master/amazon-locations?file=index.ts)
+
+> [!WARNING]
+> Please make sure you recreate the `.env` file from this repository in your Stackblitz project.
 
 Or run it locally:
 
@@ -17,5 +20,6 @@ yarn
 ```
 
 Commands:
-* `npm dev` is the development target, to serve the app and hot reload.
-* `npm run build` is the production target, to create the final bundle and write to disk.
+
+- `npm dev` is the development target, to serve the app and hot reload.
+- `npm run build` is the production target, to create the final bundle and write to disk.

--- a/boundaries/README.md
+++ b/boundaries/README.md
@@ -10,6 +10,9 @@ Uses [Vite](https://vitejs.dev/) to bundle and serve files.
 
 [![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/CartoDB/deck.gl-examples/tree/master/boundaries?file=index.ts)
 
+> [!WARNING]
+> Please make sure you recreate the `.env` file from this repository in your Stackblitz project.
+
 Or run it locally:
 
 ```bash
@@ -19,5 +22,6 @@ yarn
 ```
 
 Commands:
-* `npm dev` is the development target, to serve the app and hot reload.
-* `npm run build` is the production target, to create the final bundle and write to disk.
+
+- `npm dev` is the development target, to serve the app and hot reload.
+- `npm run build` is the production target, to create the final bundle and write to disk.

--- a/carto-colors/README.md
+++ b/carto-colors/README.md
@@ -6,10 +6,12 @@ CARTO Colors provides data-driven color schemes, custom color schemes built on t
 
 Uses [Vite](https://vitejs.dev/) to bundle and serve files.
 
-
 ## Usage
 
 [![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/CartoDB/deck.gl-examples/tree/master/carto-colors?file=index.ts)
+
+> [!WARNING]
+> Please make sure you recreate the `.env` file from this repository in your Stackblitz project.
 
 Or run it locally:
 
@@ -20,5 +22,6 @@ yarn
 ```
 
 Commands:
-* `npm dev` is the development target, to serve the app and hot reload.
-* `npm run build` is the production target, to create the final bundle and write to disk.
+
+- `npm dev` is the development target, to serve the app and hot reload.
+- `npm run build` is the production target, to create the final bundle and write to disk.

--- a/custom-markers/README.md
+++ b/custom-markers/README.md
@@ -4,11 +4,12 @@ This visualization is using [Dynamic Tiling](https://carto.com/blog/dynamic-tili
 
 Uses [Vite](https://vitejs.dev/) to bundle and serve files.
 
-
-
 ## Usage
 
 [![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/CartoDB/deck.gl-examples/tree/master/custom-markers?file=index.ts)
+
+> [!WARNING]
+> Please make sure you recreate the `.env` file from this repository in your Stackblitz project.
 
 Or run it locally:
 
@@ -19,5 +20,6 @@ yarn
 ```
 
 Commands:
-* `npm dev` is the development target, to serve the app and hot reload.
-* `npm run build` is the production target, to create the final bundle and write to disk.
+
+- `npm dev` is the development target, to serve the app and hot reload.
+- `npm run build` is the production target, to create the final bundle and write to disk.

--- a/dynamic-tiling-heatmap/README.md
+++ b/dynamic-tiling-heatmap/README.md
@@ -13,6 +13,9 @@ Uses [Vite](https://vitejs.dev/) to bundle and serve files.
 
 [![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/CartoDB/deck.gl-examples/tree/master/dynamic-tiling-heatmap?file=index.ts)
 
+> [!WARNING]
+> Please make sure you recreate the `.env` file from this repository in your Stackblitz project.
+
 Or run it locally:
 
 ```bash

--- a/dynamic-tiling-pois/README.md
+++ b/dynamic-tiling-pois/README.md
@@ -4,11 +4,12 @@ This visualization is using [Dynamic Tiling](https://carto.com/blog/dynamic-tili
 
 Uses [Vite](https://vitejs.dev/) to bundle and serve files.
 
-
-
 ## Usage
 
 [![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/CartoDB/deck.gl-examples/tree/master/dynamic-tiling-pois?file=index.ts)
+
+> [!WARNING]
+> Please make sure you recreate the `.env` file from this repository in your Stackblitz project.
 
 Or run it locally:
 
@@ -19,5 +20,6 @@ yarn
 ```
 
 Commands:
-* `npm dev` is the development target, to serve the app and hot reload.
-* `npm run build` is the production target, to create the final bundle and write to disk.
+
+- `npm dev` is the development target, to serve the app and hot reload.
+- `npm run build` is the production target, to create the final bundle and write to disk.

--- a/globe-view/README.md
+++ b/globe-view/README.md
@@ -8,6 +8,9 @@ Uses [Vite](https://vitejs.dev/) to bundle and serve files.
 
 [![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/CartoDB/deck.gl-examples/tree/master/globe-view?file=index.ts)
 
+> [!WARNING]
+> Please make sure you recreate the `.env` file from this repository in your Stackblitz project.
+
 Or run it locally:
 
 ```bash
@@ -17,5 +20,6 @@ yarn
 ```
 
 Commands:
-* `npm run dev` is the development target, to serve the app and hot reload.
-* `npm run build` is the production target, to create the final bundle and write to disk.
+
+- `npm run dev` is the development target, to serve the app and hot reload.
+- `npm run build` is the production target, to create the final bundle and write to disk.

--- a/google-basemap/README.md
+++ b/google-basemap/README.md
@@ -8,6 +8,9 @@ Uses [Vite](https://vitejs.dev/) to bundle and serve files.
 
 [![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/CartoDB/deck.gl-examples/tree/master/google-basemap?file=index.ts)
 
+> [!WARNING]
+> Please make sure you recreate the `.env` file from this repository in your Stackblitz project.
+
 Or run it locally:
 
 ```bash
@@ -17,5 +20,6 @@ yarn
 ```
 
 Commands:
-* `npm dev` is the development target, to serve the app and hot reload.
-* `npm run build` is the production target, to create the final bundle and write to disk.
+
+- `npm dev` is the development target, to serve the app and hot reload.
+- `npm run build` is the production target, to create the final bundle and write to disk.

--- a/hello-world-with-widgets/README.md
+++ b/hello-world-with-widgets/README.md
@@ -12,6 +12,9 @@ Uses [Vite](https://vitejs.dev/) to bundle and serve files.
 
 [![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/CartoDB/deck.gl-examples/tree/master/hello-world-with-widgets?file=index.ts)
 
+> [!WARNING]
+> Please make sure you recreate the `.env` file from this repository in your Stackblitz project.
+
 Or run it locally:
 
 ```bash

--- a/hello-world/README.md
+++ b/hello-world/README.md
@@ -8,6 +8,9 @@ Uses [Vite](https://vitejs.dev/) to bundle and serve files.
 
 [![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/CartoDB/deck.gl-examples/tree/master/hello-world?file=index.ts)
 
+> [!WARNING]
+> Please make sure you recreate the `.env` file from this repository in your Stackblitz project.
+
 Or run it locally:
 
 ```bash

--- a/labels/README.md
+++ b/labels/README.md
@@ -4,10 +4,12 @@ This visualization is using [TextLayer](https://deck.gl/docs/api-reference/layer
 
 Uses [Vite](https://vitejs.dev/) to bundle and serve files.
 
-
 ## Usage
 
 [![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/CartoDB/deck.gl-examples/tree/master/labels?file=index.ts)
+
+> [!WARNING]
+> Please make sure you recreate the `.env` file from this repository in your Stackblitz project.
 
 Or run it locally:
 
@@ -18,5 +20,6 @@ yarn
 ```
 
 Commands:
-* `npm dev` is the development target, to serve the app and hot reload.
-* `npm run build` is the production target, to create the final bundle and write to disk.
+
+- `npm dev` is the development target, to serve the app and hot reload.
+- `npm run build` is the production target, to create the final bundle and write to disk.

--- a/named-sources/README.md
+++ b/named-sources/README.md
@@ -10,6 +10,9 @@ Uses [Vite](https://vitejs.dev/) to bundle and serve files.
 
 [![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/CartoDB/deck.gl-examples/tree/master/named-sources?file=index.ts)
 
+> [!WARNING]
+> Please make sure you recreate the `.env` file from this repository in your Stackblitz project.
+
 Or run it locally:
 
 ```bash

--- a/query-accidents/README.md
+++ b/query-accidents/README.md
@@ -4,10 +4,12 @@ You can use SQL to query data directly from the app, including query parameters.
 
 Uses [Vite](https://vitejs.dev/) to bundle and serve files.
 
-
 ## Usage
 
 [![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/CartoDB/deck.gl-examples/tree/master/query-accidents?file=index.ts)
+
+> [!WARNING]
+> Please make sure you recreate the `.env` file from this repository in your Stackblitz project.
 
 Or run it locally:
 
@@ -18,5 +20,6 @@ yarn
 ```
 
 Commands:
-* `npm dev` is the development target, to serve the app and hot reload.
-* `npm run build` is the production target, to create the final bundle and write to disk.
+
+- `npm dev` is the development target, to serve the app and hot reload.
+- `npm run build` is the production target, to create the final bundle and write to disk.

--- a/raster-temperature/README.md
+++ b/raster-temperature/README.md
@@ -8,6 +8,9 @@ Uses [Vite](https://vitejs.dev/) to bundle and serve files.
 
 [![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/CartoDB/deck.gl-examples/tree/master/raster-temperature?file=index.ts)
 
+> [!WARNING]
+> Please make sure you recreate the `.env` file from this repository in your Stackblitz project.
+
 Or run it locally:
 
 ```bash
@@ -17,5 +20,6 @@ yarn
 ```
 
 Commands:
-* `npm dev` is the development target, to serve the app and hot reload.
-* `npm run build` is the production target, to create the final bundle and write to disk.
+
+- `npm dev` is the development target, to serve the app and hot reload.
+- `npm run build` is the production target, to create the final bundle and write to disk.

--- a/spatial-features-h3/README.md
+++ b/spatial-features-h3/README.md
@@ -1,12 +1,15 @@
 ## Example: Spatial Index H3
 
-This is a great example on how performant spatial indexes are to visualize and operate with large geospatial datasets. In this case we're using a dataset based in an hexagonal grid (H3), from our CARTO Data Observatory. This datasets includes demographic, financial, and environmental variables across the US. CARTO + deck.gl offer native support for spatial indexes. If you want to learn more about spatial indexes, we recommend you to check our [Spatial Indexes 101 guide](https://go.carto.com/report-spatial-indexes-101).  
+This is a great example on how performant spatial indexes are to visualize and operate with large geospatial datasets. In this case we're using a dataset based in an hexagonal grid (H3), from our CARTO Data Observatory. This datasets includes demographic, financial, and environmental variables across the US. CARTO + deck.gl offer native support for spatial indexes. If you want to learn more about spatial indexes, we recommend you to check our [Spatial Indexes 101 guide](https://go.carto.com/report-spatial-indexes-101).
 
 Uses [Vite](https://vitejs.dev/) to bundle and serve files.
 
 ## Usage
 
 [![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/CartoDB/deck.gl-examples/tree/master/spatial-features-h3?file=index.ts)
+
+> [!WARNING]
+> Please make sure you recreate the `.env` file from this repository in your Stackblitz project.
 
 Or run it locally:
 
@@ -17,5 +20,6 @@ yarn
 ```
 
 Commands:
-* `npm dev` is the development target, to serve the app and hot reload.
-* `npm run build` is the production target, to create the final bundle and write to disk.
+
+- `npm dev` is the development target, to serve the app and hot reload.
+- `npm run build` is the production target, to create the final bundle and write to disk.

--- a/spatial-features-quadbin/README.md
+++ b/spatial-features-quadbin/README.md
@@ -1,12 +1,15 @@
 ## Example: Spatial indexes (Quadbin)
 
-This is a great example on how performant spatial indexes are to visualize and operate with large geospatial datasets. In this case we're using a dataset based in a square grid (Quadbin), from our CARTO Data Observatory. This datasets includes demographic, financial, and environmental variables across Spain. CARTO + deck.gl offer native support for spatial indexes. If you want to learn more about spatial indexes, we recommend you to check our [Spatial Indexes 101 guide](https://go.carto.com/report-spatial-indexes-101).  
+This is a great example on how performant spatial indexes are to visualize and operate with large geospatial datasets. In this case we're using a dataset based in a square grid (Quadbin), from our CARTO Data Observatory. This datasets includes demographic, financial, and environmental variables across Spain. CARTO + deck.gl offer native support for spatial indexes. If you want to learn more about spatial indexes, we recommend you to check our [Spatial Indexes 101 guide](https://go.carto.com/report-spatial-indexes-101).
 
 Uses [Vite](https://vitejs.dev/) to bundle and serve files.
 
 ## Usage
 
 [![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/CartoDB/deck.gl-examples/tree/master/spatial-features-quadbin?file=index.ts)
+
+> [!WARNING]
+> Please make sure you recreate the `.env` file from this repository in your Stackblitz project.
 
 Or run it locally:
 
@@ -17,5 +20,6 @@ yarn
 ```
 
 Commands:
-* `npm run dev` is the development target, to serve the app and hot reload.
-* `npm run build` is the production target, to create the final bundle and write to disk.
+
+- `npm run dev` is the development target, to serve the app and hot reload.
+- `npm run build` is the production target, to create the final bundle and write to disk.

--- a/tileset-buildings/README.md
+++ b/tileset-buildings/README.md
@@ -8,6 +8,9 @@ Uses [Vite](https://vitejs.dev/) to bundle and serve files.
 
 [![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/CartoDB/deck.gl-examples/tree/master/tileset-buildings?file=index.ts)
 
+> [!WARNING]
+> Please make sure you recreate the `.env` file from this repository in your Stackblitz project.
+
 Or run it locally:
 
 ```bash
@@ -17,5 +20,6 @@ yarn
 ```
 
 Commands:
-* `npm dev` is the development target, to serve the app and hot reload.
-* `npm run build` is the production target, to create the final bundle and write to disk.
+
+- `npm dev` is the development target, to serve the app and hot reload.
+- `npm run build` is the production target, to create the final bundle and write to disk.

--- a/trips/README.md
+++ b/trips/README.md
@@ -8,6 +8,9 @@ Uses [Vite](https://vitejs.dev/) to bundle and serve files.
 
 [![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/CartoDB/deck.gl-examples/tree/master/trips?file=index.ts)
 
+> [!WARNING]
+> Please make sure you recreate the `.env` file from this repository in your Stackblitz project.
+
 Or run it locally:
 
 ```bash
@@ -17,5 +20,6 @@ yarn
 ```
 
 Commands:
-* `npm dev` is the development target, to serve the app and hot reload.
-* `npm run build` is the production target, to create the final bundle and write to disk.
+
+- `npm dev` is the development target, to serve the app and hot reload.
+- `npm run build` is the production target, to create the final bundle and write to disk.

--- a/widgets-categories/README.md
+++ b/widgets-categories/README.md
@@ -10,6 +10,9 @@ Uses [Vite](https://vitejs.dev/) to bundle and serve files.
 
 [![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/CartoDB/deck.gl-examples/tree/master/widgets-categories?file=index.ts)
 
+> [!WARNING]
+> Please make sure you recreate the `.env` file from this repository in your Stackblitz project.
+
 Or run it locally:
 
 ```bash

--- a/widgets-formula/README.md
+++ b/widgets-formula/README.md
@@ -8,6 +8,9 @@ Uses [Vite](https://vitejs.dev/) to bundle and serve files.
 
 [![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/CartoDB/deck.gl-examples/tree/master/widgets-formula?file=index.ts)
 
+> [!WARNING]
+> Please make sure you recreate the `.env` file from this repository in your Stackblitz project.
+
 Or run it locally:
 
 ```bash

--- a/widgets-h3/README.md
+++ b/widgets-h3/README.md
@@ -12,6 +12,9 @@ Uses [Vite](https://vitejs.dev/) to bundle and serve files.
 
 [![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/CartoDB/deck.gl-examples/tree/master/widgets-h3?file=index.ts)
 
+> [!WARNING]
+> Please make sure you recreate the `.env` file from this repository in your Stackblitz project.
+
 Or run it locally:
 
 ```bash

--- a/widgets-histogram/README.md
+++ b/widgets-histogram/README.md
@@ -10,6 +10,9 @@ Uses [Vite](https://vitejs.dev/) to bundle and serve files.
 
 [![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/CartoDB/deck.gl-examples/tree/master/widgets-histogram?file=index.ts)
 
+> [!WARNING]
+> Please make sure you recreate the `.env` file from this repository in your Stackblitz project.
+
 Or run it locally:
 
 ```bash

--- a/widgets-other-charts/README.md
+++ b/widgets-other-charts/README.md
@@ -12,6 +12,9 @@ Uses [Vite](https://vitejs.dev/) to bundle and serve files.
 
 [![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/CartoDB/deck.gl-examples/tree/master/widgets-other-charts?file=index.ts)
 
+> [!WARNING]
+> Please make sure you recreate the `.env` file from this repository in your Stackblitz project.
+
 Or run it locally:
 
 ```bash

--- a/widgets-quadbin/README.md
+++ b/widgets-quadbin/README.md
@@ -12,6 +12,9 @@ Uses [Vite](https://vitejs.dev/) to bundle and serve files.
 
 [![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/CartoDB/deck.gl-examples/tree/master/widgets-quadbin?file=index.ts)
 
+> [!WARNING]
+> Please make sure you recreate the `.env` file from this repository in your Stackblitz project.
+
 Or run it locally:
 
 ```bash

--- a/widgets-range/README.md
+++ b/widgets-range/README.md
@@ -10,6 +10,9 @@ Uses [Vite](https://vitejs.dev/) to bundle and serve files.
 
 [![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/CartoDB/deck.gl-examples/tree/master/widgets-range?file=index.ts)
 
+> [!WARNING]
+> Please make sure you recreate the `.env` file from this repository in your Stackblitz project.
+
 Or run it locally:
 
 ```bash

--- a/widgets-scatterplot/README.md
+++ b/widgets-scatterplot/README.md
@@ -10,6 +10,9 @@ Uses [Vite](https://vitejs.dev/) to bundle and serve files.
 
 [![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/CartoDB/deck.gl-examples/tree/master/widgets-scatterplot?file=index.ts)
 
+> [!WARNING]  
+> Please make sure you recreate the `.env` file from this repository in your Stackblitz project.
+
 Or run it locally:
 
 ```bash

--- a/widgets-table/README.md
+++ b/widgets-table/README.md
@@ -10,6 +10,9 @@ Uses [Vite](https://vitejs.dev/) to bundle and serve files.
 
 [![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/CartoDB/deck.gl-examples/tree/master/widgets-table?file=index.ts)
 
+> [!WARNING]
+> Please make sure you recreate the `.env` file from this repository in your Stackblitz project.
+
 Or run it locally:
 
 ```bash

--- a/widgets-time-series/README.md
+++ b/widgets-time-series/README.md
@@ -12,6 +12,9 @@ Uses [Vite](https://vitejs.dev/) to bundle and serve files.
 
 [![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/CartoDB/deck.gl-examples/tree/master/widgets-time-series?file=index.ts)
 
+> [!WARNING]
+> Please make sure you recreate the `.env` file from this repository in your Stackblitz project.
+
 Or run it locally:
 
 ```bash


### PR DESCRIPTION
This PR adds warning notes to all `readme.md` files for all examples, like this one:

> [!WARNING]  
> Please make sure you recreate the `.env` file from this repository in your Stackblitz project.

This warning arises from this issue: https://github.com/stackblitz/webcontainer-core/issues/1545 — which has not been solved and has no ETA in place