### PR TITLE
feat(widgets,h3,quadbin): Update API client, remove spatialIndexReferenceViewState

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,8 +2,8 @@
   "name": "deck-gl-examples",
   "version": "1.0.0",
   "devDependencies": {
-    "vite": "^4.5.0",
-    "ocular-dev-tools": "^2.0.0-alpha.15"
+    "ocular-dev-tools": "^2.0.0-alpha.15",
+    "vite": "^4.5.0"
   },
   "packageManager": "yarn@4.4.1+sha512.f825273d0689cc9ead3259c14998037662f1dcd06912637b21a450e8da7cfeb4b1965bbee73d16927baa1201054126bc385c6f43ff4aa705c8631d26e12460f1"
 }

--- a/widgets-h3/index.ts
+++ b/widgets-h3/index.ts
@@ -136,8 +136,7 @@ async function renderFormula(ws: WidgetSource) {
   const formula = await ws.getFormula({
     column: selectedVariable,
     operation: 'sum',
-    spatialFilter: getSpatialFilterFromViewState(viewState),
-    spatialIndexReferenceViewState: viewState
+    spatialFilter: getSpatialFilterFromViewState(viewState)
   });
   formulaWidget.textContent = Intl.NumberFormat('en-US', {
     maximumFractionDigits: 0

--- a/widgets-h3/package.json
+++ b/widgets-h3/package.json
@@ -15,7 +15,7 @@
     "vite": "^4.5.0"
   },
   "dependencies": {
-    "@carto/api-client": "^0.4.4",
+    "@carto/api-client": "^0.4.9",
     "@deck.gl/aggregation-layers": "^9.0.17",
     "@deck.gl/carto": "^9.0.17",
     "@deck.gl/core": "^9.0.17",

--- a/widgets-quadbin/index.ts
+++ b/widgets-quadbin/index.ts
@@ -128,8 +128,7 @@ async function renderFormula(ws: WidgetSource) {
   const formula = await ws.getFormula({
     column: selectedVariable,
     operation: 'sum',
-    spatialFilter: getSpatialFilterFromViewState(viewState),
-    spatialIndexReferenceViewState: viewState
+    spatialFilter: getSpatialFilterFromViewState(viewState)
   });
   formulaWidget.textContent = Intl.NumberFormat('en-US', {
     maximumFractionDigits: 0

--- a/widgets-quadbin/package.json
+++ b/widgets-quadbin/package.json
@@ -15,7 +15,7 @@
     "vite": "^4.5.0"
   },
   "dependencies": {
-    "@carto/api-client": "^0.4.4",
+    "@carto/api-client": "^0.4.9",
     "@deck.gl/aggregation-layers": "^9.0.17",
     "@deck.gl/carto": "^9.0.17",
     "@deck.gl/core": "^9.0.17",


### PR DESCRIPTION
Removes `spatialIndexReferenceViewState` parameter. The API now determines spatial filter resolution from the spatial filter, not the view state.