### PR TITLE
Fetchmap example

### DIFF
--- a/fetchmap/README.md
+++ b/fetchmap/README.md
@@ -1,0 +1,32 @@
+## Example: fetchMap
+
+This example demonstrates how to use the `fetchMap` function from `@carto/api-client` (version 0.5.2 or higher) to retrieve the configuration of a map created in CARTO Builder and render it using Deck.gl.
+
+## Description
+
+The application initializes a Deck.gl instance, fetches map data (including layers, initial view state, and other configurations) using a specific `mapId`, and then renders the map.
+
+It also displays two simple widgets:
+
+1.  **Map Name**: Shows the title of the fetched CARTO map.
+2.  **Number of Layers**: Shows the count of layers in the fetched CARTO map.
+
+## Usage
+
+[![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/CartoDB/deck.gl-examples/tree/master/fetchmap?file=index.ts)
+
+> [!WARNING]
+> Please make sure you recreate the `.env` file from this repository in your Stackblitz project.
+
+Or run it locally:
+
+```bash
+npm install
+# or
+yarn
+```
+
+Commands:
+
+- `npm run dev` is the development target, to serve the app and hot reload.
+- `npm run build` is the production target, to create the final bundle and write to disk.

--- a/fetchmap/README.md
+++ b/fetchmap/README.md
@@ -1,15 +1,8 @@
 ## Example: fetchMap
 
-This example demonstrates how to use the `fetchMap` function from `@carto/api-client` (version 0.5.2 or higher) to retrieve the configuration of a map created in CARTO Builder and render it using Deck.gl.
+This example demonstrates how to use the `fetchMap` function from `@carto/api-client` (version 0.5.5 or higher) to retrieve the configuration of a map created in CARTO Builder and render it using Deck.gl. Developers can then customize those layers and integrate them in their own application layers. This enables developers to collaborate with cartographers and other non-developers who will create layers directlly in CARTO, and greatly reduces the time to create an application.
 
-## Description
-
-The application initializes a Deck.gl instance, fetches map data (including layers, initial view state, and other configurations) using a specific `mapId`, and then renders the map.
-
-It also displays two simple widgets:
-
-1.  **Map Name**: Shows the title of the fetched CARTO map.
-2.  **Number of Layers**: Shows the count of layers in the fetched CARTO map.
+Check the [documentation and technical reference for fetchMap](https://docs.carto.com/carto-for-developers/reference/fetchmap) to learn more.
 
 ## Usage
 

--- a/fetchmap/index.html
+++ b/fetchmap/index.html
@@ -31,25 +31,22 @@
         <p class="overline">✨👀 You're viewing</p>
         <h2>fetchMap Example</h2>
         <p>
-          This example demonstrates using <code>fetchMap</code> from
-          <code>@carto/api-client</code> to retrieve CARTO map details and display them.
-        </p>
-        <p>
-          It showcases how to integrate a map created in CARTO Builder into a Deck.gl application.
-          The data sheet below will display some information derived from the map data.
+          This example showcases how to integrate a map created in CARTO Builder into a custom CARTO
+          + Deck.gl application. It uses <code>fetchMap</code> from
+          <code>@carto/api-client</code> to retrieve the map configuration and layers.
         </p>
         <p class="small">
           Learn more about
           <a
-            href="https://docs.carto.com/carto-for-developers/carto-vl-and-deck-gl/integrations/deck.gl"
+            href="https://docs.carto.com/carto-for-developers/reference/fetchmap"
             rel="noopener noreferrer"
             target="_blank"
-            >CARTO & deck.gl integration</a
+            >fetchMap</a
           >.
         </p>
 
         <div id="map-selector-container" class="content-section-container">
-          <h3 class="map-selector-title">Select available maps</h3>
+          <h3 class="map-selector-title">Select one or more available maps</h3>
           <!-- Checkboxes will be dynamically inserted here by the script -->
           <button id="load-maps-button" class="map-selector-button">Load Maps</button>
         </div>
@@ -58,7 +55,7 @@
           <h3 class="map-selector-title">Loaded maps</h3>
           <div id="map-info-widget">
             <dl>
-              <dt>Map Title:</dt>
+              <dt>Map Title(s):</dt>
               <dd id="mapName">Loading...</dd>
 
               <dt>Number of Layers:</dt>
@@ -68,7 +65,15 @@
         </div>
 
         <hr />
-        <p class="caption">Map data from CARTO</p>
+        <p class="caption">
+          Source:
+          <a
+            href="https://carto.com/spatial-data-catalog/browser"
+            rel="noopener noreferrer"
+            target="_blank"
+            >CARTO Data Observatory</a
+          >
+        </p>
       </div>
     </div>
     <script type="module" src="./index.ts"></script>

--- a/fetchmap/index.html
+++ b/fetchmap/index.html
@@ -1,0 +1,76 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link
+      rel="icon"
+      type="image/png"
+      sizes="32x32"
+      href="https://app.carto.com/favicon/favicon-32x32.png"
+    />
+    <link
+      rel="icon"
+      type="image/png"
+      sizes="16x16"
+      href="https://app.carto.com/favicon/favicon-16x16.png"
+    />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&display=swap"
+      rel="stylesheet"
+    />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>CARTO + deck.gl - fetchMap Example</title>
+  </head>
+  <body>
+    <div id="app">
+      <div id="map"></div>
+      <canvas id="deck-canvas"></canvas>
+      <div id="story-card">
+        <p class="overline">✨👀 You're viewing</p>
+        <h2>fetchMap Example</h2>
+        <p>
+          This example demonstrates using <code>fetchMap</code> from
+          <code>@carto/api-client</code> to retrieve CARTO map details and display them.
+        </p>
+        <p>
+          It showcases how to integrate a map created in CARTO Builder into a Deck.gl application.
+          The data sheet below will display some information derived from the map data.
+        </p>
+        <p class="small">
+          Learn more about
+          <a
+            href="https://docs.carto.com/carto-for-developers/carto-vl-and-deck-gl/integrations/deck.gl"
+            rel="noopener noreferrer"
+            target="_blank"
+            >CARTO & deck.gl integration</a
+          >.
+        </p>
+
+        <div id="map-selector-container" class="content-section-container">
+          <h3 class="map-selector-title">Select available maps</h3>
+          <!-- Checkboxes will be dynamically inserted here by the script -->
+          <button id="load-maps-button" class="map-selector-button">Load Maps</button>
+        </div>
+
+        <div class="content-section-container">
+          <h3 class="map-selector-title">Loaded maps</h3>
+          <div id="map-info-widget">
+            <dl>
+              <dt>Map Title:</dt>
+              <dd id="mapName">Loading...</dd>
+
+              <dt>Number of Layers:</dt>
+              <dd id="layerCount">Loading...</dd>
+            </dl>
+          </div>
+        </div>
+
+        <hr />
+        <p class="caption">Map data from CARTO</p>
+      </div>
+    </div>
+    <script type="module" src="./index.ts"></script>
+  </body>
+</html>

--- a/fetchmap/index.ts
+++ b/fetchmap/index.ts
@@ -4,11 +4,10 @@ import 'maplibre-gl/dist/maplibre-gl.css';
 import {Deck, Layer} from '@deck.gl/core';
 import {fetchMap, FetchMapResult, LayerDescriptor} from '@carto/api-client';
 import {BASEMAP} from '@deck.gl/carto';
-// import {debounce} from './utils'; // Commenting out for now, to keep it simple
 import {LayerFactory} from './utils';
-// LayerDescriptor is now imported from @carto/api-client directly
 import {createLegend} from './legend';
 import './legend.css';
+import {buildTooltip} from './tooltip';
 
 const apiBaseUrl = import.meta.env.VITE_API_BASE_URL;
 
@@ -37,11 +36,10 @@ const baseFetchMapOptions = {
 // HTML Elements
 const mapNameEl = document.querySelector<HTMLDListElement>('#mapName');
 const layerCountEl = document.querySelector<HTMLDListElement>('#layerCount');
-// Ensure these elements exist in your HTML for the map selector
 const mapSelectorContainer = document.getElementById('map-selector-container');
 const loadMapsButton = document.getElementById('load-maps-button');
 
-// Initial Deck.gl view state - this might be updated by fetchMap data
+// Initial Deck.gl view state - this will be updated by fetchMap data
 const INITIAL_VIEW_STATE = {
   latitude: 0,
   longitude: 0,
@@ -55,131 +53,12 @@ const deck = new Deck({
   initialViewState: INITIAL_VIEW_STATE,
   controller: true,
   onViewStateChange: ({viewState}) => {
-    // Synchronize MapLibreGL view with DeckGL
     const {longitude, latitude, ...rest} = viewState;
     map.jumpTo({center: [longitude, latitude], ...rest});
   },
   getTooltip: ({object, layer}) => {
-    if (
-      !object ||
-      !layer ||
-      !currentMapData || // Check against the aggregated currentMapData
-      !currentMapData.popupSettings ||
-      !currentMapData.popupSettings.layers
-    ) {
-      return null;
-    }
-
-    const layerId = layer.id;
-    const popupLayersSettings = currentMapData.popupSettings.layers;
-
-    // Check if settings exist for this layer and if the layer's popups are enabled overall
-    if (!popupLayersSettings[layerId] || !popupLayersSettings[layerId].enabled) {
-      return null;
-    }
-
-    const layerSettings = popupLayersSettings[layerId];
-    let eventConfig = null; // This will hold either hover or click config
-
-    // Prioritize hover for getTooltip, then click
-    if (
-      layerSettings.hover &&
-      layerSettings.hover.fields &&
-      layerSettings.hover.fields.length > 0
-    ) {
-      eventConfig = layerSettings.hover;
-    } else if (
-      layerSettings.click &&
-      layerSettings.click.fields &&
-      layerSettings.click.fields.length > 0
-    ) {
-      eventConfig = layerSettings.click;
-    }
-
-    if (!eventConfig) {
-      return null;
-    }
-
-    const fieldsToDisplay = eventConfig.fields;
-    let htmlContent = '';
-
-    // Use layer's friendly name if available
-    const layerDisplayName = (layer.props as any)?.cartoLabel || layer.props.id || layerId;
-    htmlContent += `<div style="margin-bottom: 5px; font-weight: bold; border-bottom: 1px solid #555; padding-bottom: 3px;">${layerDisplayName}</div>`;
-
-    htmlContent += '<table style="border-collapse: collapse;">';
-    for (const field of fieldsToDisplay) {
-      const originalFieldName = field.name;
-      let actualFieldName = originalFieldName;
-
-      // Construct the actual field name if spatialIndexAggregation is present
-      if (
-        field.spatialIndexAggregation &&
-        typeof field.spatialIndexAggregation === 'string' &&
-        field.spatialIndexAggregation.length > 0
-      ) {
-        actualFieldName = `${originalFieldName}_${field.spatialIndexAggregation}`;
-      }
-
-      const displayName = field.customName || originalFieldName;
-      let valueToDisplay: string | number = 'N/A';
-
-      if (object.properties && object.properties.hasOwnProperty(actualFieldName)) {
-        const rawValue = object.properties[actualFieldName];
-
-        if (rawValue !== null && rawValue !== undefined) {
-          if (typeof rawValue === 'number' && field.format) {
-            try {
-              const formatSpec = field.format;
-              let formattedNumber: string | number = rawValue;
-              if (formatSpec.endsWith('s')) {
-                const precision = formatSpec.includes('.')
-                  ? parseInt(formatSpec.match(/\.(\d)/)?.[1] || '2')
-                  : 0;
-                if (Math.abs(rawValue) >= 1e9)
-                  formattedNumber = (rawValue / 1e9).toFixed(precision) + 'B';
-                else if (Math.abs(rawValue) >= 1e6)
-                  formattedNumber = (rawValue / 1e6).toFixed(precision) + 'M';
-                else if (Math.abs(rawValue) >= 1e3)
-                  formattedNumber = (rawValue / 1e3).toFixed(precision) + 'k';
-                else formattedNumber = rawValue.toFixed(precision);
-              } else if (
-                formatSpec.includes('.') &&
-                (formatSpec.endsWith('f') ||
-                  /^\.\d$/.test(formatSpec) ||
-                  /^\.\d~$/.test(formatSpec))
-              ) {
-                const precision = parseInt(formatSpec.match(/\.(\d)/)?.[1] || '2');
-                formattedNumber = rawValue.toFixed(precision);
-              }
-              valueToDisplay = formattedNumber;
-            } catch (e) {
-              // console.warn('Error formatting numeric value:', rawValue, 'with format:', field.format, e);
-              valueToDisplay = String(rawValue);
-            }
-          } else {
-            valueToDisplay = String(rawValue);
-          }
-        }
-        // If rawValue is null or undefined, valueToDisplay remains 'N/A' as initialized
-      }
-      // If fieldName is not in object.properties, valueToDisplay remains 'N/A' as initialized
-
-      htmlContent += `<tr><td style="padding-right: 10px; opacity: 0.8;"><em>${displayName}</em>:</td><td>${valueToDisplay}</td></tr>`;
-    }
-    htmlContent += '</table>';
-
-    return {
-      html: `<div style="font-family: Arial, sans-serif; font-size: 12px;">${htmlContent}</div>`,
-      style: {
-        backgroundColor: 'rgba(20, 20, 20, 0.9)',
-        color: 'white',
-        padding: '10px',
-        borderRadius: '5px',
-        boxShadow: '0 2px 10px rgba(0,0,0,0.2)',
-        maxWidth: '300px'
-      }
-    };
+    if (!layer) return null;
+    return buildTooltip(object, layer, currentMapData);
   }
 });
 
@@ -201,7 +80,6 @@ async function initialize(selectedMapIds: string[]) {
     currentMapData = null;
 
     if (selectedMapIds.length === 0) {
-      console.log('No maps selected. Clearing map.');
       if (mapNameEl) mapNameEl.innerHTML = 'No Map Selected';
       if (layerCountEl) layerCountEl.innerHTML = '0';
       map.jumpTo({
@@ -214,26 +92,20 @@ async function initialize(selectedMapIds: string[]) {
       return;
     }
 
-    console.log(`Fetching maps with IDs: ${selectedMapIds.join(', ')}`);
-
+    // Fetch map data for each selected map
     const allFetchedMapData: FetchMapResult[] = [];
     for (const mapId of selectedMapIds) {
-      const mapConfig = MAP_CONFIGS.find(mc => mc.id === mapId);
-      console.log(`Fetching map: ${mapConfig ? mapConfig.name : mapId}`);
       try {
         const fetchOptions = {...baseFetchMapOptions, cartoMapId: mapId};
         const mapData = await fetchMap(fetchOptions);
         allFetchedMapData.push(mapData);
       } catch (error) {
-        console.error(`Failed to fetch map data for ID ${mapId}:`, error);
         // Optionally, show a partial error or skip this map
       }
     }
 
-    console.log('allFetchedMapData:', allFetchedMapData);
-
+    // If no maps were fetched, show an error
     if (allFetchedMapData.length === 0) {
-      console.error('No map data could be fetched for selected IDs.');
       if (mapNameEl) mapNameEl.innerHTML = 'Error loading maps';
       if (layerCountEl) layerCountEl.innerHTML = 'Error';
       return;
@@ -286,8 +158,6 @@ async function initialize(selectedMapIds: string[]) {
       initialViewState: finalInitialViewState
     };
 
-    console.log('Aggregated map data:', currentMapData);
-
     // Update widgets
     if (mapNameEl) {
       mapNameEl.innerHTML = currentMapData.title;
@@ -299,8 +169,9 @@ async function initialize(selectedMapIds: string[]) {
     // Create and append the new legend for combined layers
     if (currentMapData.layers && currentMapData.layers.length > 0) {
       const legendElement = createLegend(currentMapData.layers);
-      document.body.appendChild(legendElement); // Consider appending to a specific legend container
+      document.body.appendChild(legendElement);
 
+      // Add event listener to toggle layer visibility
       legendElement.addEventListener('togglelayervisibility', (event: Event) => {
         const customEvent = event as CustomEvent<{layerId: string; visible: boolean}>;
         const {layerId, visible} = customEvent.detail;
@@ -313,90 +184,9 @@ async function initialize(selectedMapIds: string[]) {
         });
         deck.setProps({layers: newLayers});
       });
-
-      // Add event listener for layer reordering from the legend
-      legendElement.addEventListener('reorderlayers', (event: Event) => {
-        const customEvent = event as CustomEvent<{layerIds: string[]}>;
-        const visuallyOrderedIds = customEvent.detail.layerIds; // Topmost in legend is first
-
-        // console.log('[Index] Received reorderlayers. Visual order (top to bottom):', visuallyOrderedIds);
-
-        if (!currentMapData || !currentMapData.layers) {
-          console.error('[Index] Cannot reorder layers: currentMapData or its layers are missing.');
-          return;
-        }
-
-        // Deck.gl renders layers such that later layers in the array are on top.
-        // So, the visually topmost layer in the legend should be the last in Deck.gl's layer array.
-        const deckOrderIds = [...visuallyOrderedIds].reverse(); // Now bottommost for Deck is first
-        // console.log('[Index] Deck.gl order (bottom to top):', deckOrderIds);
-
-        const originalLayerDescriptors = [...currentMapData.layers]; // Preserve original for lookup
-        const reorderedLayerDescriptors: LayerDescriptor[] = [];
-
-        deckOrderIds.forEach(idFromLegendEvent => {
-          // Find the original LayerDescriptor by its ID
-          // The ID in legend.ts is: ((layer.props as any)?.id || `layer-${index}`)
-          // We try to match primarily against (l.props as any)?.id
-          const foundLayer = originalLayerDescriptors.find(l => {
-            const propsId = (l.props as any)?.id;
-            if (propsId) {
-              return propsId === idFromLegendEvent;
-            }
-            // If props.id was not available, the legend would have used `layer-${originalIndex}`.
-            // Matching this back is complex if the originalLayerDescriptors array has been sorted before,
-            // as the original index is lost. For this reordering to work robustly when props.id is missing,
-            // a stable unique ID would need to be ensured on each LayerDescriptor beforehand.
-            // For now, we prioritize matching on props.id. If it's missing, this layer might not be found
-            // unless the idFromLegendEvent (e.g. "layer-0") coincidentally matches another layer's props.id.
-            // This is a known limitation if props.id is not universally present and used by the legend.
-            return false; // Cannot reliably match `layer-${index}` style IDs here without original indices.
-          });
-
-          if (foundLayer) {
-            reorderedLayerDescriptors.push(foundLayer);
-          } else {
-            // If not found by props.id, attempt to find by the `layer-${index}` pattern IF the idFromLegendEvent looks like one.
-            // This is a less robust fallback.
-            if (idFromLegendEvent.startsWith('layer-')) {
-              const originalIndex = parseInt(idFromLegendEvent.split('-')[1], 10);
-              if (!isNaN(originalIndex) && originalIndex < originalLayerDescriptors.length) {
-                // Check if the layer at this original index in the *current* (potentially sorted)
-                // originalLayerDescriptors actually LACKS a props.id. If it had one, it should have matched above.
-                const potentialMatch = originalLayerDescriptors[originalIndex];
-                if (potentialMatch && !(potentialMatch.props as any)?.id) {
-                  // This is a heuristic: assumes originalLayerDescriptors hasn't been re-sorted in a way that invalidates this index.
-                  // And that this layer indeed was one that got a generated ID.
-                  console.warn(
-                    `[Index] Attempting fallback match for ID '${idFromLegendEvent}' using original index ${originalIndex}. This is less reliable.`
-                  );
-                  reorderedLayerDescriptors.push(potentialMatch);
-                  return; // continue to next idFromLegendEvent
-                }
-              }
-            }
-            console.warn(
-              `[Index] Layer with ID '${idFromLegendEvent}' not reliably found in currentMapData.layers during reorder.`
-            );
-          }
-        });
-
-        if (reorderedLayerDescriptors.length !== originalLayerDescriptors.length) {
-          console.error(
-            '[Index] Mismatch in layer count after reordering. Aborting Deck.gl update to prevent errors.'
-          );
-          // Restore currentMapData.layers to its state before attempting reorder to avoid partial updates.
-          // currentMapData.layers = originalLayerDescriptors; // Or re-fetch / be careful here.
-          return;
-        }
-
-        currentMapData.layers = reorderedLayerDescriptors; // Update the source of truth for descriptors
-        const newDeckLayers = LayerFactory(currentMapData.layers);
-        deck.setProps({layers: newDeckLayers});
-        // console.log('[Index] Deck layers updated with new Z-order.');
-      });
     }
 
+    // Finally, update the deck.gl view state and layers
     deck.setProps({
       initialViewState: finalInitialViewState,
       layers: LayerFactory(currentMapData.layers)
@@ -409,7 +199,6 @@ async function initialize(selectedMapIds: string[]) {
       pitch: finalInitialViewState.pitch
     });
   } catch (error) {
-    console.error('Failed to initialize maps:', error);
     if (mapNameEl) mapNameEl.innerHTML = 'Error loading map(s)';
     if (layerCountEl) layerCountEl.innerHTML = 'Error';
     currentMapData = null; // Clear data on error
@@ -417,24 +206,17 @@ async function initialize(selectedMapIds: string[]) {
   }
 }
 
+// Initialize map selector and load default map(s)
 function setupMapSelector() {
   if (!mapSelectorContainer || !loadMapsButton) {
-    console.warn(
-      'Map selector HTML elements (#map-selector-container, #load-maps-button) not found. UI for map selection will not be available.'
-    );
     // Fallback: Load the first map by default if UI elements are missing but configs exist
     if (MAP_CONFIGS.length > 0) {
-      console.log('Loading the first configured map by default.');
       initialize([MAP_CONFIGS[0].id]);
     } else {
-      console.error('No maps configured and no selector UI found. Cannot load any map.');
       initialize([]); // Show "No Map Selected" or similar
     }
     return;
   }
-
-  // Clear any existing checkboxes (e.g., if this function is called multiple times)
-  mapSelectorContainer.innerHTML = '<h3 style="margin-top:0;">Select available maps</h3>';
 
   MAP_CONFIGS.forEach((mapConfig, index) => {
     const checkbox = document.createElement('input');
@@ -447,16 +229,14 @@ function setupMapSelector() {
     const label = document.createElement('label');
     label.htmlFor = checkbox.id;
     label.textContent = mapConfig.name;
-    label.style.marginLeft = '5px'; // This will be overridden by CSS if more specific styles are added
 
     const div = document.createElement('div');
-    div.className = 'map-selector-option'; // Added class for styling
+    div.className = 'map-selector-option';
     div.appendChild(checkbox);
     div.appendChild(label);
     mapSelectorContainer.appendChild(div);
   });
 
-  // Append the button back if it was cleared by innerHTML
   mapSelectorContainer.appendChild(loadMapsButton);
 
   loadMapsButton.addEventListener('click', () => {

--- a/fetchmap/index.ts
+++ b/fetchmap/index.ts
@@ -1,0 +1,485 @@
+import './style.css';
+import maplibregl from 'maplibre-gl';
+import 'maplibre-gl/dist/maplibre-gl.css';
+import {Deck, Layer} from '@deck.gl/core';
+import {fetchMap, FetchMapResult, LayerDescriptor} from '@carto/api-client';
+import {BASEMAP} from '@deck.gl/carto';
+// import {debounce} from './utils'; // Commenting out for now, to keep it simple
+import {LayerFactory} from './utils';
+// LayerDescriptor is now imported from @carto/api-client directly
+import {createLegend} from './legend';
+import './legend.css';
+
+const apiBaseUrl = import.meta.env.VITE_API_BASE_URL;
+
+// Define configurations for multiple maps
+const MAP_CONFIGS = [
+  {id: '26bce5fe-29d4-48dc-914f-14355971f143', name: 'US Weather'},
+  {id: '6ac6f3bb-9c90-4e7e-9ecd-3c7343704c24', name: 'US Wind Map'}
+];
+
+// Define the structure for aggregated map data
+interface AggregatedMapData {
+  title: string;
+  layers: LayerDescriptor[];
+  popupSettings: FetchMapResult['popupSettings'] | null;
+  initialViewState?: Deck['props']['initialViewState'];
+}
+
+let currentMapData: AggregatedMapData | null = null; // Stores aggregated data from selected maps
+
+// Base options for fetchMap, cartoMapId will be added per call
+const baseFetchMapOptions = {
+  apiBaseUrl
+  // accessToken: import.meta.env.VITE_CARTO_ACCESS_TOKEN // if you want to use a private (non-public) map
+};
+
+// HTML Elements
+const mapNameEl = document.querySelector<HTMLDListElement>('#mapName');
+const layerCountEl = document.querySelector<HTMLDListElement>('#layerCount');
+// Ensure these elements exist in your HTML for the map selector
+const mapSelectorContainer = document.getElementById('map-selector-container');
+const loadMapsButton = document.getElementById('load-maps-button');
+
+// Initial Deck.gl view state - this might be updated by fetchMap data
+const INITIAL_VIEW_STATE = {
+  latitude: 0,
+  longitude: 0,
+  zoom: 1,
+  bearing: 0,
+  pitch: 0
+};
+
+const deck = new Deck({
+  canvas: 'deck-canvas',
+  initialViewState: INITIAL_VIEW_STATE,
+  controller: true,
+  onViewStateChange: ({viewState}) => {
+    // Synchronize MapLibreGL view with DeckGL
+    const {longitude, latitude, ...rest} = viewState;
+    map.jumpTo({center: [longitude, latitude], ...rest});
+  },
+  getTooltip: ({object, layer}) => {
+    if (
+      !object ||
+      !layer ||
+      !currentMapData || // Check against the aggregated currentMapData
+      !currentMapData.popupSettings ||
+      !currentMapData.popupSettings.layers
+    ) {
+      return null;
+    }
+
+    const layerId = layer.id;
+    const popupLayersSettings = currentMapData.popupSettings.layers;
+
+    // Check if settings exist for this layer and if the layer's popups are enabled overall
+    if (!popupLayersSettings[layerId] || !popupLayersSettings[layerId].enabled) {
+      return null;
+    }
+
+    const layerSettings = popupLayersSettings[layerId];
+    let eventConfig = null; // This will hold either hover or click config
+
+    // Prioritize hover for getTooltip, then click
+    if (
+      layerSettings.hover &&
+      layerSettings.hover.fields &&
+      layerSettings.hover.fields.length > 0
+    ) {
+      eventConfig = layerSettings.hover;
+    } else if (
+      layerSettings.click &&
+      layerSettings.click.fields &&
+      layerSettings.click.fields.length > 0
+    ) {
+      eventConfig = layerSettings.click;
+    }
+
+    if (!eventConfig) {
+      return null;
+    }
+
+    const fieldsToDisplay = eventConfig.fields;
+    let htmlContent = '';
+
+    // Use layer's friendly name if available
+    const layerDisplayName = (layer.props as any)?.cartoLabel || layer.props.id || layerId;
+    htmlContent += `<div style="margin-bottom: 5px; font-weight: bold; border-bottom: 1px solid #555; padding-bottom: 3px;">${layerDisplayName}</div>`;
+
+    htmlContent += '<table style="border-collapse: collapse;">';
+    for (const field of fieldsToDisplay) {
+      const originalFieldName = field.name;
+      let actualFieldName = originalFieldName;
+
+      // Construct the actual field name if spatialIndexAggregation is present
+      if (
+        field.spatialIndexAggregation &&
+        typeof field.spatialIndexAggregation === 'string' &&
+        field.spatialIndexAggregation.length > 0
+      ) {
+        actualFieldName = `${originalFieldName}_${field.spatialIndexAggregation}`;
+      }
+
+      const displayName = field.customName || originalFieldName;
+      let valueToDisplay: string | number = 'N/A';
+
+      if (object.properties && object.properties.hasOwnProperty(actualFieldName)) {
+        const rawValue = object.properties[actualFieldName];
+
+        if (rawValue !== null && rawValue !== undefined) {
+          if (typeof rawValue === 'number' && field.format) {
+            try {
+              const formatSpec = field.format;
+              let formattedNumber: string | number = rawValue;
+              if (formatSpec.endsWith('s')) {
+                const precision = formatSpec.includes('.')
+                  ? parseInt(formatSpec.match(/\.(\d)/)?.[1] || '2')
+                  : 0;
+                if (Math.abs(rawValue) >= 1e9)
+                  formattedNumber = (rawValue / 1e9).toFixed(precision) + 'B';
+                else if (Math.abs(rawValue) >= 1e6)
+                  formattedNumber = (rawValue / 1e6).toFixed(precision) + 'M';
+                else if (Math.abs(rawValue) >= 1e3)
+                  formattedNumber = (rawValue / 1e3).toFixed(precision) + 'k';
+                else formattedNumber = rawValue.toFixed(precision);
+              } else if (
+                formatSpec.includes('.') &&
+                (formatSpec.endsWith('f') ||
+                  /^\.\d$/.test(formatSpec) ||
+                  /^\.\d~$/.test(formatSpec))
+              ) {
+                const precision = parseInt(formatSpec.match(/\.(\d)/)?.[1] || '2');
+                formattedNumber = rawValue.toFixed(precision);
+              }
+              valueToDisplay = formattedNumber;
+            } catch (e) {
+              // console.warn('Error formatting numeric value:', rawValue, 'with format:', field.format, e);
+              valueToDisplay = String(rawValue);
+            }
+          } else {
+            valueToDisplay = String(rawValue);
+          }
+        }
+        // If rawValue is null or undefined, valueToDisplay remains 'N/A' as initialized
+      }
+      // If fieldName is not in object.properties, valueToDisplay remains 'N/A' as initialized
+
+      htmlContent += `<tr><td style="padding-right: 10px; opacity: 0.8;"><em>${displayName}</em>:</td><td>${valueToDisplay}</td></tr>`;
+    }
+    htmlContent += '</table>';
+
+    return {
+      html: `<div style="font-family: Arial, sans-serif; font-size: 12px;">${htmlContent}</div>`,
+      style: {
+        backgroundColor: 'rgba(20, 20, 20, 0.9)',
+        color: 'white',
+        padding: '10px',
+        borderRadius: '5px',
+        boxShadow: '0 2px 10px rgba(0,0,0,0.2)',
+        maxWidth: '300px'
+      }
+    };
+  }
+});
+
+// Add basemap
+const map = new maplibregl.Map({
+  container: 'map',
+  style: BASEMAP.VOYAGER, // Using Voyager as a default
+  interactive: false
+});
+
+async function initialize(selectedMapIds: string[]) {
+  try {
+    // Clear previous map state
+    const existingLegend = document.querySelector('.legend-wrapper');
+    if (existingLegend) {
+      existingLegend.remove();
+    }
+    deck.setProps({layers: []});
+    currentMapData = null;
+
+    if (selectedMapIds.length === 0) {
+      console.log('No maps selected. Clearing map.');
+      if (mapNameEl) mapNameEl.innerHTML = 'No Map Selected';
+      if (layerCountEl) layerCountEl.innerHTML = '0';
+      map.jumpTo({
+        center: [INITIAL_VIEW_STATE.longitude, INITIAL_VIEW_STATE.latitude],
+        zoom: INITIAL_VIEW_STATE.zoom,
+        bearing: INITIAL_VIEW_STATE.bearing,
+        pitch: INITIAL_VIEW_STATE.pitch
+      });
+      deck.setProps({initialViewState: INITIAL_VIEW_STATE});
+      return;
+    }
+
+    console.log(`Fetching maps with IDs: ${selectedMapIds.join(', ')}`);
+
+    const allFetchedMapData: FetchMapResult[] = [];
+    for (const mapId of selectedMapIds) {
+      const mapConfig = MAP_CONFIGS.find(mc => mc.id === mapId);
+      console.log(`Fetching map: ${mapConfig ? mapConfig.name : mapId}`);
+      try {
+        const fetchOptions = {...baseFetchMapOptions, cartoMapId: mapId};
+        const mapData = await fetchMap(fetchOptions);
+        allFetchedMapData.push(mapData);
+      } catch (error) {
+        console.error(`Failed to fetch map data for ID ${mapId}:`, error);
+        // Optionally, show a partial error or skip this map
+      }
+    }
+
+    console.log('allFetchedMapData:', allFetchedMapData);
+
+    if (allFetchedMapData.length === 0) {
+      console.error('No map data could be fetched for selected IDs.');
+      if (mapNameEl) mapNameEl.innerHTML = 'Error loading maps';
+      if (layerCountEl) layerCountEl.innerHTML = 'Error';
+      return;
+    }
+
+    // Aggregate data from all fetched maps
+    const aggregatedLayers: LayerDescriptor[] = [];
+    const mergedPopupSettingsLayers: NonNullable<
+      NonNullable<FetchMapResult['popupSettings']>['layers']
+    > = {};
+    let finalInitialViewState = {...INITIAL_VIEW_STATE};
+    const mapTitles: string[] = [];
+
+    allFetchedMapData.forEach((mapData, index) => {
+      mapTitles.push(mapData.title || `Map ${index + 1}`);
+      if (mapData.layers) {
+        aggregatedLayers.push(...mapData.layers);
+      }
+      if (mapData.popupSettings && mapData.popupSettings.layers) {
+        for (const layerId in mapData.popupSettings.layers) {
+          // Simple merge: last one wins if layer IDs conflict across maps.
+          mergedPopupSettingsLayers[layerId] = mapData.popupSettings.layers[layerId];
+        }
+      }
+
+      // Use initial view state from the first successfully fetched map
+      if (index === 0) {
+        // Prioritize the first map's view state
+        if (mapData.initialViewState) {
+          finalInitialViewState = {...INITIAL_VIEW_STATE, ...mapData.initialViewState};
+        } else if ((mapData as any).mapOptions && (mapData as any).mapOptions.viewState) {
+          finalInitialViewState = {
+            longitude: (mapData as any).mapOptions.viewState.longitude,
+            latitude: (mapData as any).mapOptions.viewState.latitude,
+            zoom: (mapData as any).mapOptions.viewState.zoom,
+            pitch: (mapData as any).mapOptions.viewState.pitch || 0,
+            bearing: (mapData as any).mapOptions.viewState.bearing || 0
+          };
+        }
+      }
+    });
+
+    currentMapData = {
+      title: mapTitles.length > 1 ? mapTitles.join(' & ') : mapTitles[0] || 'Untitled Map',
+      layers: aggregatedLayers,
+      popupSettings:
+        Object.keys(mergedPopupSettingsLayers).length > 0
+          ? {layers: mergedPopupSettingsLayers}
+          : null,
+      initialViewState: finalInitialViewState
+    };
+
+    console.log('Aggregated map data:', currentMapData);
+
+    // Update widgets
+    if (mapNameEl) {
+      mapNameEl.innerHTML = currentMapData.title;
+    }
+    if (layerCountEl) {
+      layerCountEl.innerHTML = currentMapData.layers.length.toString();
+    }
+
+    // Create and append the new legend for combined layers
+    if (currentMapData.layers && currentMapData.layers.length > 0) {
+      const legendElement = createLegend(currentMapData.layers);
+      document.body.appendChild(legendElement); // Consider appending to a specific legend container
+
+      legendElement.addEventListener('togglelayervisibility', (event: Event) => {
+        const customEvent = event as CustomEvent<{layerId: string; visible: boolean}>;
+        const {layerId, visible} = customEvent.detail;
+        const currentDeckLayers = (deck.props.layers || []) as Layer[];
+        const newLayers = currentDeckLayers.map((layer: Layer) => {
+          if (layer && layer.id === layerId) {
+            return layer.clone({visible});
+          }
+          return layer;
+        });
+        deck.setProps({layers: newLayers});
+      });
+
+      // Add event listener for layer reordering from the legend
+      legendElement.addEventListener('reorderlayers', (event: Event) => {
+        const customEvent = event as CustomEvent<{layerIds: string[]}>;
+        const visuallyOrderedIds = customEvent.detail.layerIds; // Topmost in legend is first
+
+        // console.log('[Index] Received reorderlayers. Visual order (top to bottom):', visuallyOrderedIds);
+
+        if (!currentMapData || !currentMapData.layers) {
+          console.error('[Index] Cannot reorder layers: currentMapData or its layers are missing.');
+          return;
+        }
+
+        // Deck.gl renders layers such that later layers in the array are on top.
+        // So, the visually topmost layer in the legend should be the last in Deck.gl's layer array.
+        const deckOrderIds = [...visuallyOrderedIds].reverse(); // Now bottommost for Deck is first
+        // console.log('[Index] Deck.gl order (bottom to top):', deckOrderIds);
+
+        const originalLayerDescriptors = [...currentMapData.layers]; // Preserve original for lookup
+        const reorderedLayerDescriptors: LayerDescriptor[] = [];
+
+        deckOrderIds.forEach(idFromLegendEvent => {
+          // Find the original LayerDescriptor by its ID
+          // The ID in legend.ts is: ((layer.props as any)?.id || `layer-${index}`)
+          // We try to match primarily against (l.props as any)?.id
+          const foundLayer = originalLayerDescriptors.find(l => {
+            const propsId = (l.props as any)?.id;
+            if (propsId) {
+              return propsId === idFromLegendEvent;
+            }
+            // If props.id was not available, the legend would have used `layer-${originalIndex}`.
+            // Matching this back is complex if the originalLayerDescriptors array has been sorted before,
+            // as the original index is lost. For this reordering to work robustly when props.id is missing,
+            // a stable unique ID would need to be ensured on each LayerDescriptor beforehand.
+            // For now, we prioritize matching on props.id. If it's missing, this layer might not be found
+            // unless the idFromLegendEvent (e.g. "layer-0") coincidentally matches another layer's props.id.
+            // This is a known limitation if props.id is not universally present and used by the legend.
+            return false; // Cannot reliably match `layer-${index}` style IDs here without original indices.
+          });
+
+          if (foundLayer) {
+            reorderedLayerDescriptors.push(foundLayer);
+          } else {
+            // If not found by props.id, attempt to find by the `layer-${index}` pattern IF the idFromLegendEvent looks like one.
+            // This is a less robust fallback.
+            if (idFromLegendEvent.startsWith('layer-')) {
+              const originalIndex = parseInt(idFromLegendEvent.split('-')[1], 10);
+              if (!isNaN(originalIndex) && originalIndex < originalLayerDescriptors.length) {
+                // Check if the layer at this original index in the *current* (potentially sorted)
+                // originalLayerDescriptors actually LACKS a props.id. If it had one, it should have matched above.
+                const potentialMatch = originalLayerDescriptors[originalIndex];
+                if (potentialMatch && !(potentialMatch.props as any)?.id) {
+                  // This is a heuristic: assumes originalLayerDescriptors hasn't been re-sorted in a way that invalidates this index.
+                  // And that this layer indeed was one that got a generated ID.
+                  console.warn(
+                    `[Index] Attempting fallback match for ID '${idFromLegendEvent}' using original index ${originalIndex}. This is less reliable.`
+                  );
+                  reorderedLayerDescriptors.push(potentialMatch);
+                  return; // continue to next idFromLegendEvent
+                }
+              }
+            }
+            console.warn(
+              `[Index] Layer with ID '${idFromLegendEvent}' not reliably found in currentMapData.layers during reorder.`
+            );
+          }
+        });
+
+        if (reorderedLayerDescriptors.length !== originalLayerDescriptors.length) {
+          console.error(
+            '[Index] Mismatch in layer count after reordering. Aborting Deck.gl update to prevent errors.'
+          );
+          // Restore currentMapData.layers to its state before attempting reorder to avoid partial updates.
+          // currentMapData.layers = originalLayerDescriptors; // Or re-fetch / be careful here.
+          return;
+        }
+
+        currentMapData.layers = reorderedLayerDescriptors; // Update the source of truth for descriptors
+        const newDeckLayers = LayerFactory(currentMapData.layers);
+        deck.setProps({layers: newDeckLayers});
+        // console.log('[Index] Deck layers updated with new Z-order.');
+      });
+    }
+
+    deck.setProps({
+      initialViewState: finalInitialViewState,
+      layers: LayerFactory(currentMapData.layers)
+    });
+
+    map.jumpTo({
+      center: [finalInitialViewState.longitude, finalInitialViewState.latitude],
+      zoom: finalInitialViewState.zoom,
+      bearing: finalInitialViewState.bearing,
+      pitch: finalInitialViewState.pitch
+    });
+  } catch (error) {
+    console.error('Failed to initialize maps:', error);
+    if (mapNameEl) mapNameEl.innerHTML = 'Error loading map(s)';
+    if (layerCountEl) layerCountEl.innerHTML = 'Error';
+    currentMapData = null; // Clear data on error
+    deck.setProps({layers: []}); // Clear layers on error
+  }
+}
+
+function setupMapSelector() {
+  if (!mapSelectorContainer || !loadMapsButton) {
+    console.warn(
+      'Map selector HTML elements (#map-selector-container, #load-maps-button) not found. UI for map selection will not be available.'
+    );
+    // Fallback: Load the first map by default if UI elements are missing but configs exist
+    if (MAP_CONFIGS.length > 0) {
+      console.log('Loading the first configured map by default.');
+      initialize([MAP_CONFIGS[0].id]);
+    } else {
+      console.error('No maps configured and no selector UI found. Cannot load any map.');
+      initialize([]); // Show "No Map Selected" or similar
+    }
+    return;
+  }
+
+  // Clear any existing checkboxes (e.g., if this function is called multiple times)
+  mapSelectorContainer.innerHTML = '<h3 style="margin-top:0;">Select available maps</h3>';
+
+  MAP_CONFIGS.forEach((mapConfig, index) => {
+    const checkbox = document.createElement('input');
+    checkbox.type = 'checkbox';
+    // Ensure unique ID for each checkbox, useful for labels
+    checkbox.id = `map-checkbox-${mapConfig.id}-${index}`;
+    checkbox.value = mapConfig.id;
+    checkbox.name = 'mapSelection';
+
+    const label = document.createElement('label');
+    label.htmlFor = checkbox.id;
+    label.textContent = mapConfig.name;
+    label.style.marginLeft = '5px'; // This will be overridden by CSS if more specific styles are added
+
+    const div = document.createElement('div');
+    div.className = 'map-selector-option'; // Added class for styling
+    div.appendChild(checkbox);
+    div.appendChild(label);
+    mapSelectorContainer.appendChild(div);
+  });
+
+  // Append the button back if it was cleared by innerHTML
+  mapSelectorContainer.appendChild(loadMapsButton);
+
+  loadMapsButton.addEventListener('click', () => {
+    const selectedCheckboxes = document.querySelectorAll<HTMLInputElement>(
+      'input[name="mapSelection"]:checked'
+    );
+    const selectedIds = Array.from(selectedCheckboxes).map(cb => cb.value);
+    initialize(selectedIds);
+  });
+
+  // Load the first map by default on initial page load
+  const firstCheckbox =
+    mapSelectorContainer.querySelector<HTMLInputElement>('input[type="checkbox"]');
+  if (firstCheckbox) {
+    firstCheckbox.checked = true;
+    initialize([firstCheckbox.value]);
+  } else if (MAP_CONFIGS.length > 0) {
+    // Fallback if somehow checkboxes weren't created but configs exist
+    initialize([MAP_CONFIGS[0].id]);
+  } else {
+    initialize([]); // No maps to load if no configs
+  }
+}
+
+// Initialize map selector and load default map(s)
+setupMapSelector();

--- a/fetchmap/legend.css
+++ b/fetchmap/legend.css
@@ -1,0 +1,209 @@
+.legend-wrapper {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  pointer-events: none;
+  display: flex;
+  justify-content: flex-end;
+  align-items: flex-end;
+}
+
+.legend-container {
+  margin: 1rem;
+  width: 180px;
+  max-height: calc(100% - 3rem);
+  overflow-y: auto;
+  background: #fdfdfe;
+  padding: 0.75rem;
+  border-radius: 4px;
+  box-shadow: 2px 2px 6px #30303099;
+  z-index: 1000;
+  font-family: Inter, sans-serif;
+  box-sizing: border-box;
+  pointer-events: auto;
+}
+
+.legend-layer {
+  margin-bottom: 8px;
+  padding-bottom: 8px;
+  border-bottom: 1px solid #eee;
+  position: relative;
+}
+
+.legend-layer:last-child {
+  border-bottom: none;
+  margin-bottom: 0;
+  padding-bottom: 0;
+}
+
+/* Styles for the container of the checkbox and layer title */
+.legend-title-container {
+  display: flex;
+  align-items: center;
+  margin-bottom: 6px;
+}
+
+.legend-title {
+  margin: 0;
+  font-family: Inter, sans-serif;
+  font-weight: 400;
+  font-size: 0.75rem;
+  line-height: 1.4;
+  letter-spacing: 0;
+  color: rgb(44, 48, 50);
+  margin-left: 8px;
+  cursor: pointer;
+}
+
+.legend-header {
+  color: #6c757d;
+  font-size: 0.65rem;
+  margin-bottom: 3px;
+  font-family: Inter, sans-serif;
+  text-transform: uppercase;
+}
+
+.legend-column {
+  margin: 0;
+  font-family: Inter, sans-serif;
+  font-weight: 400;
+  font-size: 0.7rem;
+  line-height: 1.4;
+  letter-spacing: 0;
+  color: rgb(44, 48, 50);
+  margin-bottom: 6px;
+}
+
+.legend-range {
+  display: flex;
+  align-items: center;
+  margin-bottom: 4px;
+}
+
+.legend-color-swatch {
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  margin-right: 6px;
+  flex-shrink: 0;
+}
+
+.legend-range-label {
+  margin: 0;
+  font-family: Inter, sans-serif;
+  font-weight: 400;
+  font-size: 0.7rem;
+  line-height: 1.4;
+  letter-spacing: 0;
+  color: rgb(44, 48, 50);
+  white-space: nowrap;
+}
+
+.legend-categories {
+  font-size: 0.7rem;
+  font-family: Inter, sans-serif;
+}
+
+/* Class for the new details container, if specific styling is needed */
+.legend-layer-details {
+  padding-left: 2px;
+  margin-top: 4px;
+  padding-left: 20px;
+}
+
+/* Drag Handler Styles */
+.legend-drag-handler {
+  display: inline-block;
+  width: 12px;
+  height: 20px;
+  margin-right: 6px;
+  cursor: grab;
+  font-family: 'sans-serif';
+  font-size: 16px;
+  line-height: 0.8;
+  text-align: center;
+  color: #aaa;
+  user-select: none;
+  letter-spacing: -2px;
+  overflow: hidden;
+  white-space: nowrap;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-around;
+  align-items: center;
+}
+
+.legend-drag-handler::before {
+  content: '\2807\2807';
+  display: none;
+}
+
+.legend-drag-handler span {
+  display: block;
+  line-height: 0.5;
+  font-size: 10px;
+}
+
+/* Drag and Drop Styles */
+.legend-layer-dragging {
+  opacity: 0.5;
+  border: 1px dashed #007bff;
+  background-color: #f0f8ff;
+}
+
+.legend-layer-dragging .legend-drag-handler {
+  cursor: grabbing;
+}
+
+/* .legend-layer-dragover { */ /* Old style, remove or repurpose if needed */
+/* border-top: 2px solid #007bff; */
+/* } */
+
+.legend-drop-above {
+  border-top: 2px solid #007bff !important; /* Blue border on top */
+  box-shadow: 0 -2px 4px -2px #007bff40 inset; /* Optional inner shadow */
+  background-color: rgba(0, 123, 255, 0.1) !important; /* Light blue background highlight */
+}
+
+.legend-drop-below {
+  border-bottom: 2px solid #007bff !important; /* Blue border on bottom */
+  box-shadow: 0 2px 4px -2px #007bff40 inset; /* Optional inner shadow */
+  background-color: rgba(0, 123, 255, 0.1) !important; /* Light blue background highlight */
+}
+
+/* Switch Toggle Styles */
+.layer-visibility-toggle {
+  appearance: none;
+  -webkit-appearance: none;
+  position: relative;
+  width: 34px;
+  height: 20px;
+  background-color: #ccc;
+  border-radius: 10px;
+  cursor: pointer;
+  transition: background-color 0.2s ease-in-out;
+  flex-shrink: 0;
+}
+
+.layer-visibility-toggle::before {
+  content: '';
+  position: absolute;
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  background-color: white;
+  top: 2px;
+  left: 2px;
+  transition: transform 0.2s ease-in-out;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2);
+}
+
+.layer-visibility-toggle:checked {
+  background-color: #4caf50;
+}
+
+.layer-visibility-toggle:checked::before {
+  transform: translateX(14px);
+}

--- a/fetchmap/legend.css
+++ b/fetchmap/legend.css
@@ -12,11 +12,11 @@
 
 .legend-container {
   margin: 1rem;
-  width: 180px;
-  max-height: calc(100% - 3rem);
-  overflow-y: auto;
+  width: 220px;
+  max-height: min(80vh, 500px);
+  overflow-y: scroll;
   background: #fdfdfe;
-  padding: 0.75rem;
+  padding: 1.25rem;
   border-radius: 4px;
   box-shadow: 2px 2px 6px #30303099;
   z-index: 1000;
@@ -25,9 +25,29 @@
   pointer-events: auto;
 }
 
+/* Custom Scrollbar for Webkit browsers (Chrome, Safari) - Overriding global hide */
+.legend-container::-webkit-scrollbar {
+  width: 8px !important;
+  display: block !important;
+}
+
+.legend-container::-webkit-scrollbar-track {
+  background: #f1f1f1 !important;
+  border-radius: 10px;
+}
+
+.legend-container::-webkit-scrollbar-thumb {
+  background: #c1c1c1 !important;
+  border-radius: 10px;
+}
+
+.legend-container::-webkit-scrollbar-thumb:hover {
+  background: #a1a1a1 !important;
+}
+
 .legend-layer {
-  margin-bottom: 8px;
-  padding-bottom: 8px;
+  margin-bottom: 12px; /* Increased margin-bottom */
+  padding-bottom: 12px; /* Increased padding-bottom */
   border-bottom: 1px solid #eee;
   position: relative;
 }
@@ -42,7 +62,7 @@
 .legend-title-container {
   display: flex;
   align-items: center;
-  margin-bottom: 6px;
+  margin-bottom: 8px; /* Increased from 6px */
 }
 
 .legend-title {
@@ -79,14 +99,14 @@
 .legend-range {
   display: flex;
   align-items: center;
-  margin-bottom: 4px;
+  margin-bottom: 6px; /* Increased from 4px */
 }
 
 .legend-color-swatch {
   width: 12px;
   height: 12px;
   border-radius: 50%;
-  margin-right: 6px;
+  margin-right: 8px; /* Increased from 6px */
   flex-shrink: 0;
 }
 
@@ -109,68 +129,8 @@
 /* Class for the new details container, if specific styling is needed */
 .legend-layer-details {
   padding-left: 2px;
-  margin-top: 4px;
-  padding-left: 20px;
-}
-
-/* Drag Handler Styles */
-.legend-drag-handler {
-  display: inline-block;
-  width: 12px;
-  height: 20px;
-  margin-right: 6px;
-  cursor: grab;
-  font-family: 'sans-serif';
-  font-size: 16px;
-  line-height: 0.8;
-  text-align: center;
-  color: #aaa;
-  user-select: none;
-  letter-spacing: -2px;
-  overflow: hidden;
-  white-space: nowrap;
-  display: flex;
-  flex-direction: column;
-  justify-content: space-around;
-  align-items: center;
-}
-
-.legend-drag-handler::before {
-  content: '\2807\2807';
-  display: none;
-}
-
-.legend-drag-handler span {
-  display: block;
-  line-height: 0.5;
-  font-size: 10px;
-}
-
-/* Drag and Drop Styles */
-.legend-layer-dragging {
-  opacity: 0.5;
-  border: 1px dashed #007bff;
-  background-color: #f0f8ff;
-}
-
-.legend-layer-dragging .legend-drag-handler {
-  cursor: grabbing;
-}
-
-/* .legend-layer-dragover { */ /* Old style, remove or repurpose if needed */
-/* border-top: 2px solid #007bff; */
-/* } */
-
-.legend-drop-above {
-  border-top: 2px solid #007bff !important; /* Blue border on top */
-  box-shadow: 0 -2px 4px -2px #007bff40 inset; /* Optional inner shadow */
-  background-color: rgba(0, 123, 255, 0.1) !important; /* Light blue background highlight */
-}
-
-.legend-drop-below {
-  border-bottom: 2px solid #007bff !important; /* Blue border on bottom */
-  box-shadow: 0 2px 4px -2px #007bff40 inset; /* Optional inner shadow */
-  background-color: rgba(0, 123, 255, 0.1) !important; /* Light blue background highlight */
+  margin-top: 6px; /* Increased from 4px */
+  padding-left: 24px; /* Increased from 20px */
 }
 
 /* Switch Toggle Styles */

--- a/fetchmap/legend.ts
+++ b/fetchmap/legend.ts
@@ -3,13 +3,18 @@ import './legend.css';
 
 // Helper function to format numbers nicely (e.g., for legend ranges)
 function formatLegendNumber(num: number): string {
-  if (Math.abs(num) >= 1e9) return (num / 1e9).toFixed(1) + 'B';
-  if (Math.abs(num) >= 1e6) return (num / 1e6).toFixed(1) + 'M';
-  if (Math.abs(num) >= 1e3) return (num / 1e3).toFixed(1) + 'k';
-  if (Number.isInteger(num)) return num.toString();
-  return num.toFixed(2);
+  if (Number.isInteger(num)) {
+    return num.toString();
+  }
+
+  return new Intl.NumberFormat('en-US', {
+    notation: 'compact',
+    maximumFractionDigits: 1,
+    compactDisplay: 'short'
+  }).format(num);
 }
 
+// Create a legend for the given layers
 export function createLegend(layers: LayerDescriptor[]): HTMLElement {
   const wrapper = document.createElement('div');
   wrapper.className = 'legend-wrapper';
@@ -163,35 +168,17 @@ export function createLegend(layers: LayerDescriptor[]): HTMLElement {
             rangeDiv.appendChild(rangeLabel);
             legendDetailsContainer.appendChild(rangeDiv);
           });
-          // console.warn(
-          //   `[Legend] Layer ${layerLabel}: Quantitative scale type '${scale.type}' with equal domain/range length. Displaying domain values directly.`
-          // );
-        } else {
-          // console.warn(
-          //   `[Legend] Layer ${layerLabel}: fillColor scale type '${scale.type}' with unhandled domain/range length combination. Domain: ${scale.domain.length}, Range: ${scale.range.length}. Skipping scale-based legend items for this scale.`
-          // );
         }
-      } else {
-        // console.warn(
-        //   `[Legend] Layer ${layerLabel}: fillColor scale domain or range is undefined. Domain: ${scale.domain?.length}, Range: ${scale.range?.length}`
-        // );
       }
     }
     // --- END LEGEND ITEMS FROM SCALES ---
 
     // Fallback to existing logic if scales didn't produce legend items
     if (!legendItemsGeneratedFromScales) {
-      // console.log(
-      //   `[Legend] Layer ${layerLabel}: No legend items from scales, falling back to props/tilestats.`
-      // );
       const getFillColorProp = (layer.props as any)?.getFillColor;
       const isConstantColor = typeof getFillColorProp !== 'function';
-      // console.log(
-      //   `[Legend] Layer ${index} isConstantColor: ${isConstantColor} (type of getFillColor: ${typeof getFillColorProp})`
-      // );
 
       if (isConstantColor) {
-        // console.log(`[Legend] Layer ${index} (fallback) rendering as CONSTANT color.`);
         const rangeDiv = document.createElement('div');
         rangeDiv.className = 'legend-range';
 
@@ -201,7 +188,6 @@ export function createLegend(layers: LayerDescriptor[]): HTMLElement {
         if (Array.isArray(color) && color.length >= 3) {
           colorSwatch.style.backgroundColor = `rgb(${color[0]}, ${color[1]}, ${color[2]})`;
         } else {
-          // console.error(`[Legend] Layer ${index} constant color is not a valid array:`, color);
           colorSwatch.style.backgroundColor = 'rgb(128, 128, 128)';
         }
 
@@ -212,167 +198,9 @@ export function createLegend(layers: LayerDescriptor[]): HTMLElement {
         rangeDiv.appendChild(colorSwatch);
         rangeDiv.appendChild(rangeLabel);
         legendDetailsContainer.appendChild(rangeDiv);
-      } else {
-        // Data-driven legend (numeric, categorical)
-        // console.log(`[Legend] Layer ${index} (fallback) attempting data-driven legend.`);
-        const widgetSource = (layer.props as any)?.data?.widgetSource?.props;
-        if (!widgetSource) {
-          // console.log(
-          //   `[Legend] Layer ${index} (fallback) no widgetSource for data-driven legend. Skipping specific items.`
-          // );
-        } else {
-          let columnsInWidgetSource = widgetSource.columns;
-          if (typeof columnsInWidgetSource === 'string') {
-            columnsInWidgetSource = [columnsInWidgetSource];
-          }
-
-          if (!Array.isArray(columnsInWidgetSource)) {
-            // console.log(
-            //   `[Legend] Layer ${index} (fallback) widgetSource.columns is not an array or string (actual type: ${typeof widgetSource.columns}). Skipping data-driven legend items.`
-            // );
-          } else {
-            const dataColumn = columnsInWidgetSource.find(
-              (col: string) => col !== widgetSource.spatialDataColumn
-            );
-            // console.log(
-            //   `[Legend] Layer ${index} (fallback) dataColumn: ${dataColumn} (available columns: ${columnsInWidgetSource?.join(
-            //     ', '
-            //   )}, spatialDataColumn: ${widgetSource.spatialDataColumn})`
-            // );
-
-            if (!dataColumn) {
-              // console.log(
-              //   `[Legend] Layer ${index} (fallback) no dataColumn found. Skipping specific items.`
-              // );
-            } else {
-              const columnHeaderDiv = document.createElement('div');
-              columnHeaderDiv.className = 'legend-header';
-              columnHeaderDiv.textContent = 'COLOR BASED ON (Fallback)';
-              legendDetailsContainer.appendChild(columnHeaderDiv);
-
-              const dataColumnDisplayDiv = document.createElement('div');
-              dataColumnDisplayDiv.className = 'legend-column';
-              dataColumnDisplayDiv.textContent = dataColumn;
-              legendDetailsContainer.appendChild(dataColumnDisplayDiv);
-
-              const tilestats = (layer.props as any)?.data?.tilestats?.layers[0]?.attributes?.find(
-                (a: any) => a.attribute === dataColumn
-              );
-              // console.log(
-              //   `[Legend] Layer ${index} (fallback) tilestats for column ${dataColumn}:`,
-              //   tilestats ? JSON.parse(JSON.stringify(tilestats)) : 'undefined'
-              // );
-
-              if (
-                tilestats &&
-                tilestats.type === 'Number' &&
-                tilestats.min !== undefined &&
-                tilestats.max !== undefined
-              ) {
-                // console.log(`[Legend] Layer ${index} (fallback) rendering as NUMERIC ramp.`);
-                const numRanges = 6;
-                const min = tilestats.min;
-                const max = tilestats.max;
-                if (min === max) {
-                  const rangeDiv = document.createElement('div');
-                  rangeDiv.className = 'legend-range';
-                  const colorSwatch = document.createElement('div');
-                  colorSwatch.className = 'legend-color-swatch';
-                  try {
-                    const color = getFillColorProp({properties: {[dataColumn]: min}});
-                    if (Array.isArray(color) && color.length >= 3) {
-                      colorSwatch.style.backgroundColor = `rgb(${color[0]}, ${color[1]}, ${color[2]})`;
-                    } else {
-                      // console.error(
-                      //   `[Legend] Layer ${index} getFillColor returned invalid color for single value ${min}:`,
-                      //   color
-                      // );
-                      colorSwatch.style.backgroundColor = 'rgb(128, 128, 128)';
-                    }
-                  } catch (e) {
-                    // console.error(
-                    //   `[Legend] Layer ${index} error calling getFillColor for single value ${min}:`,
-                    //   e
-                    // );
-                    colorSwatch.style.backgroundColor = 'rgb(128, 128, 128)';
-                  }
-                  const rangeLabel = document.createElement('div');
-                  rangeLabel.className = 'legend-range-label';
-                  rangeLabel.textContent = `${min.toFixed(2)}`;
-                  rangeDiv.appendChild(colorSwatch);
-                  rangeDiv.appendChild(rangeLabel);
-                  legendDetailsContainer.appendChild(rangeDiv);
-                } else {
-                  const step = (max - min) / numRanges;
-                  for (let i = 0; i < numRanges; i++) {
-                    const rangeStart = min + step * i;
-                    const rangeEnd = i === numRanges - 1 ? max : min + step * (i + 1);
-
-                    const rangeDiv = document.createElement('div');
-                    rangeDiv.className = 'legend-range';
-
-                    const colorSwatch = document.createElement('div');
-                    colorSwatch.className = 'legend-color-swatch';
-                    const value = (rangeStart + rangeEnd) / 2;
-                    try {
-                      const color = getFillColorProp({
-                        properties: {[dataColumn]: value}
-                      });
-                      if (Array.isArray(color) && color.length >= 3) {
-                        colorSwatch.style.backgroundColor = `rgb(${color[0]}, ${color[1]}, ${color[2]})`;
-                      } else {
-                        // console.error(
-                        //   `[Legend] Layer ${index} getFillColor function returned invalid color for value ${value}:`,
-                        //   color
-                        // );
-                        colorSwatch.style.backgroundColor = 'rgb(128, 128, 128)';
-                      }
-                    } catch (e) {
-                      // console.error(
-                      //   `[Legend] Layer ${index} error calling getFillColor for value ${value}:`,
-                      //   e
-                      // );
-                      colorSwatch.style.backgroundColor = 'rgb(128, 128, 128)';
-                    }
-
-                    const rangeLabel = document.createElement('div');
-                    rangeLabel.className = 'legend-range-label';
-                    rangeLabel.textContent = `${rangeStart.toFixed(2)} – ${rangeEnd.toFixed(2)}`;
-
-                    rangeDiv.appendChild(colorSwatch);
-                    rangeDiv.appendChild(rangeLabel);
-                    legendDetailsContainer.appendChild(rangeDiv);
-                  }
-                }
-              } else if (tilestats?.type === 'String' && tilestats.categories) {
-                // console.log(`[Legend] Layer ${index} (fallback) rendering as CATEGORIES.`);
-                const categoriesDiv = document.createElement('div');
-                categoriesDiv.className = 'legend-categories';
-                // console.log(
-                //   `[Legend] Layer ${index} (fallback) categories:`,
-                //   tilestats.categories.map((c: any) => c.category)
-                // );
-                categoriesDiv.textContent = `Categories: ${tilestats.categories.length}`;
-                legendDetailsContainer.appendChild(categoriesDiv);
-              } else {
-                // console.log(
-                //   `[Legend] Layer ${index} (fallback) data-driven legend conditions not met (e.g., missing/invalid tilestats).`
-                // );
-                // if (tilestats) {
-                //   console.log(
-                //     `  tilestats.type: ${tilestats.type}, tilestats.min: ${
-                //       tilestats.min
-                //     }, tilestats.max: ${tilestats.max}, tilestats.categories: ${
-                //       tilestats.categories ? tilestats.categories.length : 'N/A'
-                //     }`
-                //   );
-                // }
-              }
-            }
-          }
-        }
       }
     }
+
     layerDiv.appendChild(legendDetailsContainer);
 
     container.appendChild(layerDiv);

--- a/fetchmap/legend.ts
+++ b/fetchmap/legend.ts
@@ -1,0 +1,510 @@
+import {LayerDescriptor, Scale, ScaleKey} from '@carto/api-client';
+import './legend.css';
+
+// Helper function to format numbers nicely (e.g., for legend ranges)
+function formatLegendNumber(num: number): string {
+  if (Math.abs(num) >= 1e9) return (num / 1e9).toFixed(1) + 'B';
+  if (Math.abs(num) >= 1e6) return (num / 1e6).toFixed(1) + 'M';
+  if (Math.abs(num) >= 1e3) return (num / 1e3).toFixed(1) + 'k';
+  if (Number.isInteger(num)) return num.toString();
+  return num.toFixed(2);
+}
+
+export function createLegend(layers: LayerDescriptor[]): HTMLElement {
+  console.log('[Legend] Creating legend for layers:', layers.length);
+  const wrapper = document.createElement('div');
+  wrapper.className = 'legend-wrapper';
+
+  const container = document.createElement('div');
+  container.className = 'legend-container';
+
+  layers.forEach((layer, index) => {
+    const layerId = ((layer.props as any)?.id || `layer-${index}`) as string;
+    const layerLabel = ((layer.props as any)?.cartoLabel || `Layer ${index + 1}`) as string;
+    const initialVisibility = (layer.props as any)?.visible !== false;
+
+    // console.log(
+    //   `[Legend] Processing layer ${index}: ${layerLabel}, ID: ${layerId}, Visible: ${initialVisibility}`
+    // );
+
+    const layerDiv = document.createElement('div');
+    layerDiv.className = 'legend-layer';
+    layerDiv.setAttribute('data-layer-id', layerId); // Store layerId for drag/drop
+    layerDiv.draggable = true; // Make the layer div draggable
+
+    layerDiv.addEventListener('dragstart', (event: DragEvent) => {
+      if (event.dataTransfer) {
+        event.dataTransfer.setData('text/plain', layerId);
+        event.dataTransfer.effectAllowed = 'move';
+      }
+      layerDiv.classList.add('legend-layer-dragging');
+      document.body.style.cursor = 'grabbing'; // Set cursor on body for global effect
+      // console.log(`[Legend] DragStart: ${layerId}`);
+    });
+
+    layerDiv.addEventListener('dragend', () => {
+      layerDiv.classList.remove('legend-layer-dragging');
+      document.body.style.cursor = ''; // Reset body cursor
+      // console.log(`[Legend] DragEnd: ${layerId}`);
+      // Clean up any stray dragover classes from all items after a drag operation concludes
+      container.querySelectorAll('.legend-layer-dragover').forEach(el => {
+        el.classList.remove('legend-layer-dragover');
+      });
+    });
+
+    layerDiv.addEventListener('dragenter', (event: DragEvent) => {
+      event.preventDefault(); // Necessary to allow drop
+      const draggingId = event.dataTransfer?.getData('text/plain');
+      if (draggingId && layerDiv.getAttribute('data-layer-id') !== draggingId) {
+        // Basic hover indication (optional, as dragover will handle specifics)
+        // layerDiv.classList.add('legend-layer-dragover-general'); // A more general hover, if desired
+      }
+    });
+
+    layerDiv.addEventListener('dragover', (event: DragEvent) => {
+      event.preventDefault(); // Necessary to allow drop
+      if (event.dataTransfer) {
+        event.dataTransfer.dropEffect = 'move';
+      }
+      const draggingId = event.dataTransfer?.getData('text/plain');
+      const currentTargetLayerId = layerDiv.getAttribute('data-layer-id');
+
+      if (draggingId && currentTargetLayerId && draggingId !== currentTargetLayerId) {
+        // Clear previous drop indicators from ALL items
+        container.querySelectorAll('.legend-drop-above, .legend-drop-below').forEach(el => {
+          el.classList.remove('legend-drop-above', 'legend-drop-below');
+        });
+
+        const rect = layerDiv.getBoundingClientRect();
+        const inUpperHalf = event.clientY < rect.top + rect.height / 2;
+
+        if (inUpperHalf) {
+          layerDiv.classList.add('legend-drop-above');
+        } else {
+          layerDiv.classList.add('legend-drop-below');
+        }
+      } else {
+        // If dragging over itself, or no valid drag, clear indicators from this specific element
+        layerDiv.classList.remove('legend-drop-above', 'legend-drop-below');
+      }
+    });
+
+    layerDiv.addEventListener('dragleave', () => {
+      layerDiv.classList.remove('legend-drop-above', 'legend-drop-below');
+      // layerDiv.classList.remove('legend-layer-dragover-general');
+    });
+
+    layerDiv.addEventListener('drop', (event: DragEvent) => {
+      event.preventDefault();
+      // Clear indicators from the dropped-upon element
+      layerDiv.classList.remove('legend-drop-above', 'legend-drop-below');
+      // Also clear from all other elements just in case dragleave didn't fire everywhere
+      container.querySelectorAll('.legend-drop-above, .legend-drop-below').forEach(el => {
+        el.classList.remove('legend-drop-above', 'legend-drop-below');
+      });
+
+      if (event.dataTransfer) {
+        const draggedLayerId = event.dataTransfer.getData('text/plain');
+        const targetLayerId = layerDiv.getAttribute('data-layer-id');
+        // console.log(`[Legend] Drop: ${draggedLayerId} onto ${targetLayerId}`);
+
+        if (draggedLayerId && targetLayerId && draggedLayerId !== targetLayerId) {
+          const layerElements = Array.from(container.children) as HTMLElement[];
+          const draggedElement = container.querySelector(`[data-layer-id="${draggedLayerId}"]`);
+          const targetElement = layerDiv; // The element being dropped onto
+
+          if (draggedElement && targetElement) {
+            // Determine if dragging upwards or downwards
+            const rect = targetElement.getBoundingClientRect();
+            const inUpperHalf = event.clientY < rect.top + rect.height / 2;
+
+            if (inUpperHalf) {
+              container.insertBefore(draggedElement, targetElement);
+            } else {
+              container.insertBefore(draggedElement, targetElement.nextSibling);
+            }
+
+            // Get the new order of layer IDs
+            const newOrderIds = (Array.from(container.children) as HTMLElement[])
+              .map(el => el.getAttribute('data-layer-id'))
+              .filter(id => id !== null) as string[];
+
+            // Dispatch custom event with the new order
+            const reorderEvent = new CustomEvent('reorderlayers', {
+              detail: {layerIds: newOrderIds}
+            });
+            wrapper.dispatchEvent(reorderEvent);
+            // console.log('[Legend] Dispatched reorderlayers:', newOrderIds);
+          }
+        }
+      }
+    });
+
+    const titleContainer = document.createElement('div');
+    titleContainer.className = 'legend-title-container';
+
+    // Create and prepend drag handler
+    const dragHandler = document.createElement('div');
+    dragHandler.className = 'legend-drag-handler';
+    // Create three dots for the drag handle
+    for (let i = 0; i < 3; i++) {
+      const dot = document.createElement('span');
+      dot.innerHTML = '&#x2022;'; // Bullet point character
+      dragHandler.appendChild(dot);
+    }
+    titleContainer.appendChild(dragHandler);
+
+    const checkbox = document.createElement('input');
+    checkbox.type = 'checkbox';
+    checkbox.id = `layer-toggle-${layerId}`;
+    checkbox.name = layerLabel;
+    checkbox.checked = initialVisibility;
+    checkbox.className = 'layer-visibility-toggle';
+
+    const legendDetailsContainer = document.createElement('div');
+    legendDetailsContainer.className = 'legend-layer-details';
+    if (!initialVisibility) {
+      legendDetailsContainer.style.display = 'none'; // Hide if layer is initially not visible
+    }
+
+    checkbox.addEventListener('change', () => {
+      const event = new CustomEvent('togglelayervisibility', {
+        detail: {
+          layerId: layerId,
+          visible: checkbox.checked
+        }
+      });
+      wrapper.dispatchEvent(event);
+
+      if (checkbox.checked) {
+        legendDetailsContainer.style.display = '';
+      } else {
+        legendDetailsContainer.style.display = 'none';
+      }
+    });
+
+    const nameDiv = document.createElement('label');
+    nameDiv.className = 'legend-title';
+    nameDiv.htmlFor = checkbox.id;
+    nameDiv.textContent = layerLabel;
+
+    titleContainer.appendChild(checkbox);
+    titleContainer.appendChild(nameDiv);
+    layerDiv.appendChild(titleContainer);
+
+    // --- START LEGEND ITEMS FROM SCALES ---
+    let legendItemsGeneratedFromScales = false;
+    if (layer.scales && layer.scales.fillColor) {
+      const scale: Scale = layer.scales.fillColor;
+      // console.log(`[Legend] Layer ${layerLabel}: Found fillColor scale`, scale);
+
+      const scaleHeaderDiv = document.createElement('div');
+      scaleHeaderDiv.className = 'legend-header';
+      scaleHeaderDiv.textContent = (scale.field?.name || 'Color').toUpperCase();
+      legendDetailsContainer.appendChild(scaleHeaderDiv);
+
+      if (scale.domain && scale.range) {
+        if (
+          (scale.type === 'ordinal' || scale.type === 'custom' || scale.type === 'point') &&
+          scale.domain.length === scale.range.length
+        ) {
+          legendItemsGeneratedFromScales = true;
+          scale.domain.forEach((domainItem, i) => {
+            const rangeDiv = document.createElement('div');
+            rangeDiv.className = 'legend-range';
+
+            const colorSwatch = document.createElement('div');
+            colorSwatch.className = 'legend-color-swatch';
+            const colorValue = scale.range[i];
+            if (typeof colorValue === 'string') {
+              colorSwatch.style.backgroundColor = colorValue;
+            } else if (Array.isArray(colorValue) && colorValue.length >= 3) {
+              colorSwatch.style.backgroundColor = `rgba(${colorValue[0]}, ${colorValue[1]}, ${
+                colorValue[2]
+              }, ${colorValue.length > 3 ? colorValue[3] / 255 : 1})`;
+            }
+
+            const rangeLabel = document.createElement('div');
+            rangeLabel.className = 'legend-range-label';
+            rangeLabel.textContent = String(domainItem);
+
+            rangeDiv.appendChild(colorSwatch);
+            rangeDiv.appendChild(rangeLabel);
+            legendDetailsContainer.appendChild(rangeDiv);
+          });
+        } else if (
+          ['quantize', 'quantile', 'linear', 'sqrt', 'log'].includes(scale.type) &&
+          scale.domain.length === scale.range.length + 1
+        ) {
+          legendItemsGeneratedFromScales = true;
+          for (let i = 0; i < scale.range.length; i++) {
+            const rangeDiv = document.createElement('div');
+            rangeDiv.className = 'legend-range';
+
+            const colorSwatch = document.createElement('div');
+            colorSwatch.className = 'legend-color-swatch';
+            const colorValue = scale.range[i];
+            if (typeof colorValue === 'string') {
+              colorSwatch.style.backgroundColor = colorValue;
+            } else if (Array.isArray(colorValue) && colorValue.length >= 3) {
+              colorSwatch.style.backgroundColor = `rgba(${colorValue[0]}, ${colorValue[1]}, ${
+                colorValue[2]
+              }, ${colorValue.length > 3 ? colorValue[3] / 255 : 1})`;
+            }
+
+            const rangeLabel = document.createElement('div');
+            rangeLabel.className = 'legend-range-label';
+            const start = formatLegendNumber(scale.domain[i] as number);
+            const end = formatLegendNumber(scale.domain[i + 1] as number);
+            rangeLabel.textContent = `${start} – ${end}`;
+
+            rangeDiv.appendChild(colorSwatch);
+            rangeDiv.appendChild(rangeLabel);
+            legendDetailsContainer.appendChild(rangeDiv);
+          }
+        } else if (
+          ['quantize', 'quantile', 'linear', 'sqrt', 'log'].includes(scale.type) &&
+          scale.domain.length === scale.range.length
+        ) {
+          legendItemsGeneratedFromScales = true;
+          scale.domain.forEach((domainItem, i) => {
+            const rangeDiv = document.createElement('div');
+            rangeDiv.className = 'legend-range';
+
+            const colorSwatch = document.createElement('div');
+            colorSwatch.className = 'legend-color-swatch';
+            const colorValue = scale.range[i];
+            if (typeof colorValue === 'string') {
+              colorSwatch.style.backgroundColor = colorValue;
+            } else if (Array.isArray(colorValue) && colorValue.length >= 3) {
+              colorSwatch.style.backgroundColor = `rgba(${colorValue[0]}, ${colorValue[1]}, ${
+                colorValue[2]
+              }, ${colorValue.length > 3 ? colorValue[3] / 255 : 1})`;
+            }
+
+            const rangeLabel = document.createElement('div');
+            rangeLabel.className = 'legend-range-label';
+            rangeLabel.textContent = formatLegendNumber(domainItem as number);
+
+            rangeDiv.appendChild(colorSwatch);
+            rangeDiv.appendChild(rangeLabel);
+            legendDetailsContainer.appendChild(rangeDiv);
+          });
+          // console.warn(
+          //   `[Legend] Layer ${layerLabel}: Quantitative scale type '${scale.type}' with equal domain/range length. Displaying domain values directly.`
+          // );
+        } else {
+          // console.warn(
+          //   `[Legend] Layer ${layerLabel}: fillColor scale type '${scale.type}' with unhandled domain/range length combination. Domain: ${scale.domain.length}, Range: ${scale.range.length}. Skipping scale-based legend items for this scale.`
+          // );
+        }
+      } else {
+        // console.warn(
+        //   `[Legend] Layer ${layerLabel}: fillColor scale domain or range is undefined. Domain: ${scale.domain?.length}, Range: ${scale.range?.length}`
+        // );
+      }
+    }
+    // --- END LEGEND ITEMS FROM SCALES ---
+
+    // Fallback to existing logic if scales didn't produce legend items
+    if (!legendItemsGeneratedFromScales) {
+      // console.log(
+      //   `[Legend] Layer ${layerLabel}: No legend items from scales, falling back to props/tilestats.`
+      // );
+      const getFillColorProp = (layer.props as any)?.getFillColor;
+      const isConstantColor = typeof getFillColorProp !== 'function';
+      // console.log(
+      //   `[Legend] Layer ${index} isConstantColor: ${isConstantColor} (type of getFillColor: ${typeof getFillColorProp})`
+      // );
+
+      if (isConstantColor) {
+        // console.log(`[Legend] Layer ${index} (fallback) rendering as CONSTANT color.`);
+        const rangeDiv = document.createElement('div');
+        rangeDiv.className = 'legend-range';
+
+        const colorSwatch = document.createElement('div');
+        colorSwatch.className = 'legend-color-swatch';
+        const color = getFillColorProp;
+        if (Array.isArray(color) && color.length >= 3) {
+          colorSwatch.style.backgroundColor = `rgb(${color[0]}, ${color[1]}, ${color[2]})`;
+        } else {
+          // console.error(`[Legend] Layer ${index} constant color is not a valid array:`, color);
+          colorSwatch.style.backgroundColor = 'rgb(128, 128, 128)';
+        }
+
+        const rangeLabel = document.createElement('div');
+        rangeLabel.className = 'legend-range-label';
+        rangeLabel.textContent = 'All values';
+
+        rangeDiv.appendChild(colorSwatch);
+        rangeDiv.appendChild(rangeLabel);
+        legendDetailsContainer.appendChild(rangeDiv);
+      } else {
+        // Data-driven legend (numeric, categorical)
+        // console.log(`[Legend] Layer ${index} (fallback) attempting data-driven legend.`);
+        const widgetSource = (layer.props as any)?.data?.widgetSource?.props;
+        if (!widgetSource) {
+          // console.log(
+          //   `[Legend] Layer ${index} (fallback) no widgetSource for data-driven legend. Skipping specific items.`
+          // );
+        } else {
+          let columnsInWidgetSource = widgetSource.columns;
+          if (typeof columnsInWidgetSource === 'string') {
+            columnsInWidgetSource = [columnsInWidgetSource];
+          }
+
+          if (!Array.isArray(columnsInWidgetSource)) {
+            // console.log(
+            //   `[Legend] Layer ${index} (fallback) widgetSource.columns is not an array or string (actual type: ${typeof widgetSource.columns}). Skipping data-driven legend items.`
+            // );
+          } else {
+            const dataColumn = columnsInWidgetSource.find(
+              (col: string) => col !== widgetSource.spatialDataColumn
+            );
+            // console.log(
+            //   `[Legend] Layer ${index} (fallback) dataColumn: ${dataColumn} (available columns: ${columnsInWidgetSource?.join(
+            //     ', '
+            //   )}, spatialDataColumn: ${widgetSource.spatialDataColumn})`
+            // );
+
+            if (!dataColumn) {
+              // console.log(
+              //   `[Legend] Layer ${index} (fallback) no dataColumn found. Skipping specific items.`
+              // );
+            } else {
+              const columnHeaderDiv = document.createElement('div');
+              columnHeaderDiv.className = 'legend-header';
+              columnHeaderDiv.textContent = 'COLOR BASED ON (Fallback)';
+              legendDetailsContainer.appendChild(columnHeaderDiv);
+
+              const dataColumnDisplayDiv = document.createElement('div');
+              dataColumnDisplayDiv.className = 'legend-column';
+              dataColumnDisplayDiv.textContent = dataColumn;
+              legendDetailsContainer.appendChild(dataColumnDisplayDiv);
+
+              const tilestats = (layer.props as any)?.data?.tilestats?.layers[0]?.attributes?.find(
+                (a: any) => a.attribute === dataColumn
+              );
+              // console.log(
+              //   `[Legend] Layer ${index} (fallback) tilestats for column ${dataColumn}:`,
+              //   tilestats ? JSON.parse(JSON.stringify(tilestats)) : 'undefined'
+              // );
+
+              if (
+                tilestats &&
+                tilestats.type === 'Number' &&
+                tilestats.min !== undefined &&
+                tilestats.max !== undefined
+              ) {
+                // console.log(`[Legend] Layer ${index} (fallback) rendering as NUMERIC ramp.`);
+                const numRanges = 6;
+                const min = tilestats.min;
+                const max = tilestats.max;
+                if (min === max) {
+                  const rangeDiv = document.createElement('div');
+                  rangeDiv.className = 'legend-range';
+                  const colorSwatch = document.createElement('div');
+                  colorSwatch.className = 'legend-color-swatch';
+                  try {
+                    const color = getFillColorProp({properties: {[dataColumn]: min}});
+                    if (Array.isArray(color) && color.length >= 3) {
+                      colorSwatch.style.backgroundColor = `rgb(${color[0]}, ${color[1]}, ${color[2]})`;
+                    } else {
+                      // console.error(
+                      //   `[Legend] Layer ${index} getFillColor returned invalid color for single value ${min}:`,
+                      //   color
+                      // );
+                      colorSwatch.style.backgroundColor = 'rgb(128, 128, 128)';
+                    }
+                  } catch (e) {
+                    // console.error(
+                    //   `[Legend] Layer ${index} error calling getFillColor for single value ${min}:`,
+                    //   e
+                    // );
+                    colorSwatch.style.backgroundColor = 'rgb(128, 128, 128)';
+                  }
+                  const rangeLabel = document.createElement('div');
+                  rangeLabel.className = 'legend-range-label';
+                  rangeLabel.textContent = `${min.toFixed(2)}`;
+                  rangeDiv.appendChild(colorSwatch);
+                  rangeDiv.appendChild(rangeLabel);
+                  legendDetailsContainer.appendChild(rangeDiv);
+                } else {
+                  const step = (max - min) / numRanges;
+                  for (let i = 0; i < numRanges; i++) {
+                    const rangeStart = min + step * i;
+                    const rangeEnd = i === numRanges - 1 ? max : min + step * (i + 1);
+
+                    const rangeDiv = document.createElement('div');
+                    rangeDiv.className = 'legend-range';
+
+                    const colorSwatch = document.createElement('div');
+                    colorSwatch.className = 'legend-color-swatch';
+                    const value = (rangeStart + rangeEnd) / 2;
+                    try {
+                      const color = getFillColorProp({
+                        properties: {[dataColumn]: value}
+                      });
+                      if (Array.isArray(color) && color.length >= 3) {
+                        colorSwatch.style.backgroundColor = `rgb(${color[0]}, ${color[1]}, ${color[2]})`;
+                      } else {
+                        // console.error(
+                        //   `[Legend] Layer ${index} getFillColor function returned invalid color for value ${value}:`,
+                        //   color
+                        // );
+                        colorSwatch.style.backgroundColor = 'rgb(128, 128, 128)';
+                      }
+                    } catch (e) {
+                      // console.error(
+                      //   `[Legend] Layer ${index} error calling getFillColor for value ${value}:`,
+                      //   e
+                      // );
+                      colorSwatch.style.backgroundColor = 'rgb(128, 128, 128)';
+                    }
+
+                    const rangeLabel = document.createElement('div');
+                    rangeLabel.className = 'legend-range-label';
+                    rangeLabel.textContent = `${rangeStart.toFixed(2)} – ${rangeEnd.toFixed(2)}`;
+
+                    rangeDiv.appendChild(colorSwatch);
+                    rangeDiv.appendChild(rangeLabel);
+                    legendDetailsContainer.appendChild(rangeDiv);
+                  }
+                }
+              } else if (tilestats?.type === 'String' && tilestats.categories) {
+                // console.log(`[Legend] Layer ${index} (fallback) rendering as CATEGORIES.`);
+                const categoriesDiv = document.createElement('div');
+                categoriesDiv.className = 'legend-categories';
+                // console.log(
+                //   `[Legend] Layer ${index} (fallback) categories:`,
+                //   tilestats.categories.map((c: any) => c.category)
+                // );
+                categoriesDiv.textContent = `Categories: ${tilestats.categories.length}`;
+                legendDetailsContainer.appendChild(categoriesDiv);
+              } else {
+                // console.log(
+                //   `[Legend] Layer ${index} (fallback) data-driven legend conditions not met (e.g., missing/invalid tilestats).`
+                // );
+                // if (tilestats) {
+                //   console.log(
+                //     `  tilestats.type: ${tilestats.type}, tilestats.min: ${
+                //       tilestats.min
+                //     }, tilestats.max: ${tilestats.max}, tilestats.categories: ${
+                //       tilestats.categories ? tilestats.categories.length : 'N/A'
+                //     }`
+                //   );
+                // }
+              }
+            }
+          }
+        }
+      }
+    }
+    layerDiv.appendChild(legendDetailsContainer);
+
+    container.appendChild(layerDiv);
+  });
+
+  wrapper.appendChild(container);
+  return wrapper;
+}

--- a/fetchmap/package.json
+++ b/fetchmap/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "carto-deckgl-example-fetchmap",
+  "version": "0.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "dev-local": "vite --config ../vite.config.local.mjs",
+    "build": "vite build",
+    "preview": "vite preview",
+    "link-deck": "yarn link @deck.gl/core && yarn link @deck.gl/layers && yarn link @deck.gl/geo-layers && yarn link @deck.gl/mesh-layers && yarn link @deck.gl/aggregation-layers && yarn link @deck.gl/carto && yarn link @deck.gl/extensions",
+    "unlink-deck": "yarn unlink @deck.gl/core && yarn link @deck.gl/layers && yarn link @deck.gl/geo-layers && yarn link @deck.gl/mesh-layers && yarn link @deck.gl/aggregation-layers && yarn link @deck.gl/carto && yarn link @deck.gl/extensions"
+  },
+  "devDependencies": {
+    "vite": "^4.5.0"
+  },
+  "dependencies": {
+    "@deck.gl/aggregation-layers": "^9.1.0",
+    "@deck.gl/carto": "^9.1.0",
+    "@deck.gl/core": "^9.1.0",
+    "@deck.gl/extensions": "^9.1.0",
+    "@deck.gl/geo-layers": "^9.1.0",
+    "@deck.gl/layers": "^9.1.0",
+    "@deck.gl/mesh-layers": "^9.1.0",
+    "@carto/api-client": "0.5.5",
+    "echarts": "^5.5.1",
+    "maplibre-gl": "^3.5.2"
+  }
+}

--- a/fetchmap/style.css
+++ b/fetchmap/style.css
@@ -1,0 +1,302 @@
+body,
+html {
+  height: 100%;
+  width: 100%;
+  overflow: hidden;
+  position: fixed;
+  font-family: Inter, sans-serif;
+  font-weight: 400;
+  font-size: 1rem;
+  line-height: 1.5;
+  margin: 0;
+}
+
+#map,
+canvas {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  max-height: 100%;
+}
+
+#app {
+  flex: 1 1 auto;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+#story-card {
+  padding: 1.75rem;
+  background: #fdfdfe;
+  box-shadow: 4px 4px 8px #30303099;
+  border-radius: 4px;
+  z-index: 1;
+  margin: 1.5rem;
+  max-width: 480px;
+  max-height: 100vh;
+  z-index: 10;
+  overflow: scroll;
+}
+
+.layer-controls {
+  margin-top: 2.25rem;
+}
+
+.overline {
+  font-size: 0.625rem;
+  font-weight: 600;
+  line-height: 1.2;
+  letter-spacing: 0.125rem;
+  text-transform: uppercase;
+}
+
+hr {
+  border: 1px solid #eee;
+  margin: 10px 0px;
+}
+
+select {
+  margin-bottom: 0.6rem;
+  border-radius: 4px;
+  font-size: 0.8rem;
+  line-height: 1.5;
+  letter-spacing: 0.001rem;
+  max-width: 100%;
+}
+
+select:hover {
+  cursor: pointer;
+}
+
+select {
+  padding: 0.6rem;
+  width: 360px;
+}
+
+code {
+  padding: 2px 5px;
+  border-radius: 5px;
+  background-color: #f0f0f0;
+}
+
+.caption {
+  margin-top: 2.25rem;
+  margin-bottom: 0px;
+  font-size: 0.8rem;
+}
+
+.widget-wrapper {
+  position: relative;
+  margin: 10px 0px;
+}
+
+.echarts-categories {
+  width: 100%;
+  height: 200px;
+}
+
+.small {
+  font-size: 0.9rem;
+}
+
+.widget-clear-filter {
+  display: none;
+  font-size: 12px;
+  text-align: right;
+  position: absolute;
+  right: 25px;
+  top: -4px;
+  color: #30303099;
+  cursor: pointer;
+}
+
+/* Hide scrollbars while maintaining scroll functionality */
+* {
+  scrollbar-width: none; /* Firefox */
+  -ms-overflow-style: none; /* Internet Explorer 10+ */
+}
+
+/* WebKit browsers (Chrome, Safari) */
+*::-webkit-scrollbar {
+  display: none;
+}
+
+/* New Widget Styles */
+#map-info-widget dl {
+  display: grid;
+  grid-template-columns: max-content auto;
+  gap: 0;
+  margin-bottom: 1rem;
+  border: 1px solid #e0e0e0;
+  border-radius: 8px;
+  overflow: hidden;
+}
+
+#map-info-widget dt {
+  font-weight: 500;
+  grid-column: 1;
+  padding: 0.65rem;
+  border-bottom: 1px solid #f0f0f0;
+  border-right: 1px solid #f0f0f0;
+  background-color: #f9f9f9;
+  font-size: 0.85rem;
+}
+
+#map-info-widget dd {
+  grid-column: 2;
+  margin-left: 0;
+  text-align: right;
+  padding: 0.65rem;
+  border-bottom: 1px solid #f0f0f0;
+  background-color: #ffffff;
+  font-size: 0.85rem;
+}
+
+#map-info-widget dt:last-of-type,
+#map-info-widget dd:last-of-type {
+  border-bottom: none;
+}
+
+#layer-details h3 {
+  font-size: 1rem;
+  font-weight: 600;
+  margin-top: 1rem;
+  margin-bottom: 0.5rem;
+}
+
+#layerList {
+  list-style: none;
+  padding-left: 0;
+  font-size: 0.9rem;
+}
+
+.layer-info-item {
+  padding: 8px;
+  margin: 5px 0;
+  border: 1px solid #eee;
+  border-radius: 4px;
+}
+
+.layer-name {
+  font-weight: 500;
+}
+
+.layer-type {
+  font-size: 0.9em;
+  margin-bottom: 5px;
+}
+
+.layer-data {
+  font-size: 0.9em;
+}
+
+#legend {
+  position: absolute;
+  bottom: 20px;
+  right: 20px;
+  padding: 10px;
+  background: white;
+  box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
+  border-radius: 4px;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell,
+    sans-serif;
+  z-index: 1000;
+  min-width: 150px;
+}
+
+.legend-title {
+  font-weight: bold;
+  margin-bottom: 10px;
+  font-size: 14px;
+  color: #2d3c43;
+}
+
+.legend-content {
+  font-size: 12px;
+}
+
+.legend-item {
+  display: flex;
+  align-items: center;
+  margin-bottom: 5px;
+}
+
+.legend-color {
+  width: 12px;
+  height: 12px;
+  margin-right: 8px;
+  border-radius: 2px;
+}
+
+.legend-label {
+  color: #2d3c43;
+}
+
+/* Styles for the Map Selector */
+.map-selector {
+  /* Any specific styles for map-selector itself, if needed, can remain here */
+  /* border-top: 1px solid #e0e0e0; */ /* This is now handled by content-section-container */
+}
+
+.content-section-container {
+  padding: 15px 0;
+  margin-top: 20px; /* Increased margin for better separation */
+  border-top: 1px solid #e0e0e0; /* Lighter border */
+}
+
+.content-section-container:first-of-type {
+  margin-top: 15px; /* Slightly less margin for the very first section if needed, or can be same */
+}
+
+.content-section-container > h3 {
+  font-size: 1rem;
+  font-weight: 700;
+  margin-top: 0;
+  margin-bottom: 12px;
+}
+
+.map-selector-option {
+  display: flex;
+  align-items: center;
+  margin-bottom: 10px; /* Increased spacing */
+}
+
+.map-selector-option input[type='checkbox'] {
+  margin-right: 8px;
+  cursor: pointer;
+  /* Optional: custom checkbox styling can be complex and might require more CSS or a library */
+  /* For a simple enhancement, you can scale it slightly if needed */
+  transform: scale(1.1);
+}
+
+.map-selector-option label {
+  font-size: 0.9rem;
+  color: #555; /* Slightly softer text color */
+  cursor: pointer;
+  flex-grow: 1; /* Allow label to take available space */
+  margin-left: 0; /* Reset margin from previous inline style */
+}
+
+.map-selector-button {
+  display: block;
+  width: 100%;
+  padding: 8px 15px; /* Adjusted padding */
+  margin-top: 15px;
+  background-color: transparent; /* Transparent background */
+  color: #4a90e2; /* Text color same as border/theme */
+  border: 1px solid #4a90e2; /* Outline border */
+  border-radius: 5px;
+  cursor: pointer;
+  text-align: center;
+  font-size: 0.9rem; /* Slightly smaller font */
+  font-weight: 500;
+  transition: background-color 0.2s ease, color 0.2s ease;
+}
+
+.map-selector-button:hover {
+  background-color: #4a90e2; /* Fill on hover */
+  color: white; /* Text color white on hover */
+}

--- a/fetchmap/tooltip.ts
+++ b/fetchmap/tooltip.ts
@@ -1,0 +1,127 @@
+import {Layer} from '@deck.gl/core';
+import {FetchMapResult} from '@carto/api-client';
+
+// Define the structure for aggregated map data expected by the tooltip function
+interface AggregatedMapDataForTooltip {
+  popupSettings: FetchMapResult['popupSettings'] | null;
+}
+
+export function buildTooltip(
+  object: any,
+  layer: Layer,
+  currentMapData: AggregatedMapDataForTooltip | null
+) {
+  if (
+    !object ||
+    !layer ||
+    !currentMapData ||
+    !currentMapData.popupSettings ||
+    !currentMapData.popupSettings.layers
+  ) {
+    return null;
+  }
+
+  const layerId = layer.id;
+  const popupLayersSettings = currentMapData.popupSettings.layers;
+
+  // Check if settings exist for this layer and if the layer's popups are enabled overall
+  if (!popupLayersSettings[layerId] || !popupLayersSettings[layerId].enabled) {
+    return null;
+  }
+
+  const layerSettings = popupLayersSettings[layerId];
+  let eventConfig = null; // This will hold either hover or click config
+
+  // Prioritize hover for getTooltip, then click
+  if (layerSettings.hover && layerSettings.hover.fields && layerSettings.hover.fields.length > 0) {
+    eventConfig = layerSettings.hover;
+  } else if (
+    layerSettings.click &&
+    layerSettings.click.fields &&
+    layerSettings.click.fields.length > 0
+  ) {
+    eventConfig = layerSettings.click;
+  }
+
+  if (!eventConfig) {
+    return null;
+  }
+
+  const fieldsToDisplay = eventConfig.fields;
+  let htmlContent = '';
+
+  // Use layer's friendly name if available
+  const layerDisplayName = (layer.props as any)?.cartoLabel || layer.props.id || layerId;
+  htmlContent += `<div style="margin-bottom: 5px; font-weight: bold; border-bottom: 1px solid #555; padding-bottom: 3px;">${layerDisplayName}</div>`;
+
+  htmlContent += '<table style="border-collapse: collapse;">';
+  for (const field of fieldsToDisplay) {
+    const originalFieldName = field.name;
+    let actualFieldName = originalFieldName;
+
+    // Construct the actual field name if spatialIndexAggregation is present
+    if (
+      field.spatialIndexAggregation &&
+      typeof field.spatialIndexAggregation === 'string' &&
+      field.spatialIndexAggregation.length > 0
+    ) {
+      actualFieldName = `${originalFieldName}_${field.spatialIndexAggregation}`;
+    }
+
+    const displayName = field.customName || originalFieldName;
+    let valueToDisplay: string | number = 'N/A';
+
+    if (object.properties && object.properties.hasOwnProperty(actualFieldName)) {
+      const rawValue = object.properties[actualFieldName];
+
+      if (rawValue !== null && rawValue !== undefined) {
+        if (typeof rawValue === 'number' && field.format) {
+          try {
+            const formatSpec = field.format;
+            let formattedNumber: string | number = rawValue;
+            if (formatSpec.endsWith('s')) {
+              const precision = formatSpec.includes('.')
+                ? parseInt(formatSpec.match(/\.(\d)/)?.[1] || '2')
+                : 0;
+              if (Math.abs(rawValue) >= 1e9)
+                formattedNumber = (rawValue / 1e9).toFixed(precision) + 'B';
+              else if (Math.abs(rawValue) >= 1e6)
+                formattedNumber = (rawValue / 1e6).toFixed(precision) + 'M';
+              else if (Math.abs(rawValue) >= 1e3)
+                formattedNumber = (rawValue / 1e3).toFixed(precision) + 'k';
+              else formattedNumber = rawValue.toFixed(precision);
+            } else if (
+              formatSpec.includes('.') &&
+              (formatSpec.endsWith('f') || /^\.\d$/.test(formatSpec) || /^\.\d~$/.test(formatSpec))
+            ) {
+              const precision = parseInt(formatSpec.match(/\.(\d)/)?.[1] || '2');
+              formattedNumber = rawValue.toFixed(precision);
+            }
+            valueToDisplay = formattedNumber;
+          } catch (e) {
+            valueToDisplay = String(rawValue);
+          }
+        } else {
+          valueToDisplay = String(rawValue);
+        }
+      }
+      // If rawValue is null or undefined, valueToDisplay remains 'N/A' as initialized
+    }
+    // If fieldName is not in object.properties, valueToDisplay remains 'N/A' as initialized
+
+    htmlContent += `<tr><td style="padding-right: 10px; opacity: 0.8;"><em>${displayName}</em>:</td><td>${valueToDisplay}</td></tr>`;
+  }
+  htmlContent += '</table>';
+
+  return {
+    html: `<div style="font-family: Arial, sans-serif; font-size: 12px;">${htmlContent}</div>`,
+    style: {
+      backgroundColor: 'rgba(20, 20, 20, 0.9)',
+      color: 'white',
+      padding: '10px',
+      borderRadius: '5px',
+      boxShadow: '0 2px 10px rgba(0,0,0,0.2)',
+      maxWidth: '300px'
+    }
+  };
+}

--- a/fetchmap/tooltip.ts
+++ b/fetchmap/tooltip.ts
@@ -83,13 +83,12 @@ export function buildTooltip(
               const precision = formatSpec.includes('.')
                 ? parseInt(formatSpec.match(/\.(\d)/)?.[1] || '2')
                 : 0;
-              if (Math.abs(rawValue) >= 1e9)
-                formattedNumber = (rawValue / 1e9).toFixed(precision) + 'B';
-              else if (Math.abs(rawValue) >= 1e6)
-                formattedNumber = (rawValue / 1e6).toFixed(precision) + 'M';
-              else if (Math.abs(rawValue) >= 1e3)
-                formattedNumber = (rawValue / 1e3).toFixed(precision) + 'k';
-              else formattedNumber = rawValue.toFixed(precision);
+              const formatter = new Intl.NumberFormat('en-US', {
+                notation: 'compact',
+                maximumFractionDigits: precision,
+                compactDisplay: 'short'
+              });
+              formattedNumber = formatter.format(rawValue);
             } else if (
               formatSpec.includes('.') &&
               (formatSpec.endsWith('f') || /^\.\d$/.test(formatSpec) || /^\.\d~$/.test(formatSpec))

--- a/fetchmap/tsconfig.json
+++ b/fetchmap/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "esnext",
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "types": ["vite/client"]
+  }
+}

--- a/fetchmap/utils.ts
+++ b/fetchmap/utils.ts
@@ -1,0 +1,48 @@
+import {getDataFilterExtensionProps, LayerDescriptor, LayerType} from '@carto/api-client';
+
+import {
+  ClusterTileLayer,
+  H3TileLayer,
+  HeatmapTileLayer,
+  VectorTileLayer,
+  QuadbinTileLayer,
+  RasterTileLayer
+} from '@deck.gl/carto';
+
+import {_ConstructorOf, Deck, Layer} from '@deck.gl/core';
+import {DataFilterExtension} from '@deck.gl/extensions';
+
+export function debounce(func, wait) {
+  let timeout;
+  return function (...args) {
+    clearTimeout(timeout);
+    timeout = setTimeout(() => func.apply(this, args), wait);
+  };
+}
+
+// For now, define here. Eventually LayerFactory will be available in @deck.gl/carto
+const layerClasses: Record<LayerType, _ConstructorOf<Layer>> = {
+  clusterTile: ClusterTileLayer,
+  h3: H3TileLayer,
+  heatmapTile: HeatmapTileLayer,
+  mvt: VectorTileLayer,
+  quadbin: QuadbinTileLayer,
+  raster: RasterTileLayer,
+  tileset: VectorTileLayer
+};
+export function LayerFactory(layers: LayerDescriptor[]) {
+  return layers
+    .map(({type, props, filters}) => {
+      const LayerClass = layerClasses[type];
+      if (!LayerClass) {
+        console.error(`No layer class found for type: ${type}`);
+        return null;
+      }
+      const filterProps = filters && {
+        ...getDataFilterExtensionProps(filters),
+        extensions: [new DataFilterExtension({filterSize: 4})]
+      };
+      return new LayerClass({...props, ...filterProps});
+    })
+    .filter(Boolean);
+}

--- a/fetchmap/utils.ts
+++ b/fetchmap/utils.ts
@@ -35,7 +35,6 @@ export function LayerFactory(layers: LayerDescriptor[]) {
     .map(({type, props, filters}) => {
       const LayerClass = layerClasses[type];
       if (!LayerClass) {
-        console.error(`No layer class found for type: ${type}`);
         return null;
       }
       const filterProps = filters && {


### PR DESCRIPTION
Adds an example using fetchMap from `@carto/api-client v0.5.5`, including:

- [x] Fetching 2 maps
- [x] Showing metadata about the maps
- [x] Merging layers from different maps
- [x] Re-building a tooltip
- [x] Re-building the legend
- [x] Letting end users show/hide layers through the legend

Pending:

- [x] Recommended implementation of `LayerFactory()`, consistent with documentation
- [x] CR

<img width="1680" alt="Screenshot 2025-05-28 at 18 27 23" src="https://github.com/user-attachments/assets/fdebe75d-312e-4547-9a11-acd7f4e87e03" />
