### PR TITLE
Add autolabels example

### DIFF
--- a/autolabels/.env
+++ b/autolabels/.env
@@ -1,0 +1,5 @@
+# API Base URL (copy this from CARTO Workspace -> Developers)
+VITE_API_BASE_URL=https://gcp-us-east1.api.carto.com
+# This API Access Token only grants access to demo data for the examples. Replace it with your own token.
+# Go to app.carto.com -> Developers -> Credentials -> API Access Tokens.
+VITE_API_ACCESS_TOKEN=eyJhbGciOiJIUzI1NiJ9.eyJhIjoiYWNfbHFlM3p3Z3UiLCJqdGkiOiJkOTU4OWMyZiJ9.78MdzU2J6y-J6Far71_Mh7IQO9eYIZD9nECUiZJAVL4

--- a/autolabels/README.md
+++ b/autolabels/README.md
@@ -1,0 +1,27 @@
+## Example: Auto Labels
+
+This example demonstrates the `autoLabels` feature of VectorTileLayer, which automatically generates labels for polygon features at their centroids.
+
+The `autoLabels` property enables automatic label generation with collision resolution (ie: non-overlapping) for lines and polygons, making it easy to add readable labels to geographic features such as zipcodes or roads without manual label placement.
+
+Uses [Vite](https://vitejs.dev/) to bundle and serve files.
+
+## Usage
+
+[![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/CartoDB/deck.gl-examples/tree/master/autolabels?file=index.ts)
+
+> [!WARNING]
+> Please make sure you recreate the `.env` file from this repository in your Stackblitz project.
+
+Or run it locally:
+
+```bash
+npm install
+# or
+yarn
+```
+
+Commands:
+
+- `npm run dev` is the development target, to serve the app and hot reload.
+- `npm run build` is the production target, to create the final bundle and write to disk.

--- a/autolabels/README.md
+++ b/autolabels/README.md
@@ -1,6 +1,10 @@
 ## Example: Auto Labels
 
-This example demonstrates the [autoLabels feature of VectorTileLayer](https://deck.gl/docs/api-reference/carto/vector-tile-layer#autolabels), which automatically generates labels for polygon features at their centroids.
+This example demonstrates the [autoLabels feature of VectorTileLayer](https://deck.gl/docs/api-reference/carto/vector-tile-layer#autolabels), which automatically generates labels for polygon and line features.
+
+The example includes two demonstrations:
+- **Polygons**: US counties with labels at their centroids, styled by population
+- **Lines**: Bristol UK cycle network with labels along routes, styled by status
 
 The `autoLabels` property enables automatic label generation with collision resolution (ie: non-overlapping) for lines and polygons, making it easy to add readable labels to geographic features such as zipcodes or roads without manual label placement.
 

--- a/autolabels/README.md
+++ b/autolabels/README.md
@@ -1,6 +1,6 @@
 ## Example: Auto Labels
 
-This example demonstrates the `autoLabels` feature of VectorTileLayer, which automatically generates labels for polygon features at their centroids.
+This example demonstrates the [autoLabels feature of VectorTileLayer](https://deck.gl/docs/api-reference/carto/vector-tile-layer#autolabels), which automatically generates labels for polygon features at their centroids.
 
 The `autoLabels` property enables automatic label generation with collision resolution (ie: non-overlapping) for lines and polygons, making it easy to add readable labels to geographic features such as zipcodes or roads without manual label placement.
 

--- a/autolabels/index.html
+++ b/autolabels/index.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link
+      rel="icon"
+      type="image/png"
+      sizes="32x32"
+      href="https://app.carto.com/favicon/favicon-32x32.png"
+    />
+    <link
+      rel="icon"
+      type="image/png"
+      sizes="16x16"
+      href="https://app.carto.com/favicon/favicon-16x16.png"
+    />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&display=swap"
+      rel="stylesheet"
+    />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>CARTO + deck.gl - Auto Labels</title>
+  <body>
+    <div id="app">
+      <div id="map"></div>
+      <canvas id="deck-canvas"></canvas>
+      <div id="story-card">
+        <p class="overline">✨👀 You're viewing</p>
+        <h2>Auto Labels for Polygons</h2>
+        <p>This example demonstrates the <code>autoLabels</code> feature of <a href="https://deck.gl/docs/api-reference/carto/vector-tile-layer">VectorTileLayer</a>, which automatically generates labels for polygon features at their centroids.</p>
+        <p>The map displays US counties with labels showing county names, styled with population-based colors. Labels are automatically positioned and include collision detection to maintain readability.</p>
+        <p class="caption">💡 Zoom in and out to see labels adjust dynamically based on the viewport.</p>
+      </div>
+    </div>
+    <script type="module" src="./index.ts"></script>
+  </body>
+</html>

--- a/autolabels/index.html
+++ b/autolabels/index.html
@@ -28,9 +28,16 @@
       <canvas id="deck-canvas"></canvas>
       <div id="story-card">
         <p class="overline">✨👀 You're viewing</p>
-        <h2>Auto Labels for Polygons</h2>
-        <p>This example demonstrates the <code>autoLabels</code> feature of <a href="https://deck.gl/docs/api-reference/carto/vector-tile-layer#autolabels">VectorTileLayer</a>, which automatically generates labels for polygon features at their centroids.</p>
-        <p>The map displays US counties with labels showing county names, styled with population-based colors. Labels are automatically positioned and include collision detection to maintain readability.</p>
+        <h2>Auto Labels</h2>
+        <p>This example demonstrates the <code>autoLabels</code> feature of <a href="https://deck.gl/docs/api-reference/carto/vector-tile-layer#autolabels">VectorTileLayer</a>, which automatically generates labels for polygon and line features.</p>
+        <div class="layer-selector">
+          Select your Auto Labels example:
+          <select id="example-selector">
+            <option value="polygons">Polygons (US Counties)</option>
+            <option value="lines">Lines (Bristol UK Cycle Network)</option>
+          </select>
+        </div>
+        <p id="description">The map displays US counties with labels showing county names, styled with population-based colors. Labels are automatically positioned and include collision detection to maintain readability.</p>
         <p class="caption">💡 Zoom in and out to see labels adjust dynamically based on the viewport.</p>
       </div>
     </div>

--- a/autolabels/index.html
+++ b/autolabels/index.html
@@ -29,7 +29,7 @@
       <div id="story-card">
         <p class="overline">✨👀 You're viewing</p>
         <h2>Auto Labels for Polygons</h2>
-        <p>This example demonstrates the <code>autoLabels</code> feature of <a href="https://deck.gl/docs/api-reference/carto/vector-tile-layer">VectorTileLayer</a>, which automatically generates labels for polygon features at their centroids.</p>
+        <p>This example demonstrates the <code>autoLabels</code> feature of <a href="https://deck.gl/docs/api-reference/carto/vector-tile-layer#autolabels">VectorTileLayer</a>, which automatically generates labels for polygon features at their centroids.</p>
         <p>The map displays US counties with labels showing county names, styled with population-based colors. Labels are automatically positioned and include collision detection to maintain readability.</p>
         <p class="caption">💡 Zoom in and out to see labels adjust dynamically based on the viewport.</p>
       </div>

--- a/autolabels/index.ts
+++ b/autolabels/index.ts
@@ -1,0 +1,74 @@
+import './style.css';
+import maplibregl from 'maplibre-gl';
+import 'maplibre-gl/dist/maplibre-gl.css';
+import {Deck} from '@deck.gl/core';
+import {BASEMAP, vectorTableSource, VectorTileLayer, colorBins} from '@deck.gl/carto';
+
+const apiBaseUrl = import.meta.env.VITE_API_BASE_URL;
+const accessToken = import.meta.env.VITE_API_ACCESS_TOKEN;
+const connectionName = 'carto_dw';
+const cartoConfig = {apiBaseUrl, accessToken, connectionName};
+
+const INITIAL_VIEW_STATE = {
+  latitude: 39.8097343,
+  longitude: -98.5556199,
+  zoom: 4,
+  bearing: 0,
+  pitch: 0
+};
+
+const dataSource = vectorTableSource({
+  ...cartoConfig,
+  tableName: 'carto-demo-data.demo_tables.usa_counties'
+});
+
+const deck = new Deck({
+  canvas: 'deck-canvas',
+  initialViewState: INITIAL_VIEW_STATE,
+  controller: true,
+  layers: [
+    new VectorTileLayer({
+      id: 'counties',
+      pickable: true,
+      data: dataSource,
+      autoLabels: true,
+      getText: f => f.properties.name,
+      pointType: 'text',
+      textSizeScale: 10,
+      getTextColor: [255, 255, 255, 255],
+      textOutlineColor: [0, 0, 0, 255],
+      textOutlineWidth: 6,
+      textFontSettings: {
+        sdf: true,
+      },
+      getFillColor: colorBins({
+        attr: 'total_pop',
+        domain: [0, 50000, 100000, 500000, 1000000, 5000000],
+        colors: 'SunsetDark'
+      }),
+      getLineColor: [0, 0, 0, 100],
+      lineWidthMinPixels: 0.5,
+      opacity: 0.9
+    })
+  ],
+  getTooltip: ({ object }) =>
+    object && {
+      html: `
+        <strong>County</strong>: ${object.properties.name}<br/>
+        <strong>Population</strong>: ${object.properties.total_pop?.toLocaleString() || 'N/A'}
+      `
+    }
+});
+
+// Add basemap
+const map = new maplibregl.Map({
+  container: 'map',
+  style: BASEMAP.POSITRON,
+  interactive: false
+});
+deck.setProps({
+  onViewStateChange: ({viewState}) => {
+    const {longitude, latitude, ...rest} = viewState;
+    map.jumpTo({center: [longitude, latitude], ...rest});
+  }
+});

--- a/autolabels/index.ts
+++ b/autolabels/index.ts
@@ -1,32 +1,58 @@
 import './style.css';
 import maplibregl from 'maplibre-gl';
 import 'maplibre-gl/dist/maplibre-gl.css';
-import {Deck} from '@deck.gl/core';
-import {BASEMAP, vectorTableSource, VectorTileLayer, colorBins} from '@deck.gl/carto';
+import {Deck, FlyToInterpolator} from '@deck.gl/core';
+import {BASEMAP, vectorTableSource, VectorTileLayer, colorBins, colorCategories} from '@deck.gl/carto';
 
 const apiBaseUrl = import.meta.env.VITE_API_BASE_URL;
 const accessToken = import.meta.env.VITE_API_ACCESS_TOKEN;
 const connectionName = 'carto_dw';
 const cartoConfig = {apiBaseUrl, accessToken, connectionName};
 
-const INITIAL_VIEW_STATE = {
-  latitude: 39.8097343,
-  longitude: -98.5556199,
-  zoom: 4,
-  bearing: 0,
-  pitch: 0
+const VIEW_STATES = {
+  polygons: {
+    latitude: 39.8097343,
+    longitude: -98.5556199,
+    zoom: 4,
+    bearing: 0,
+    pitch: 0
+  },
+  lines: {
+    latitude: 51.4545,
+    longitude: -2.5879,
+    zoom: 11,
+    bearing: 0,
+    pitch: 0
+  }
 };
-
-const dataSource = vectorTableSource({
-  ...cartoConfig,
-  tableName: 'carto-demo-data.demo_tables.usa_counties'
-});
 
 const deck = new Deck({
   canvas: 'deck-canvas',
-  initialViewState: INITIAL_VIEW_STATE,
-  controller: true,
-  layers: [
+  initialViewState: VIEW_STATES.polygons,
+  controller: true
+});
+
+// Add basemap
+const map = new maplibregl.Map({
+  container: 'map',
+  style: BASEMAP.POSITRON,
+  interactive: false
+});
+
+deck.setProps({
+  onViewStateChange: ({viewState}) => {
+    const {longitude, latitude, ...rest} = viewState;
+    map.jumpTo({center: [longitude, latitude], ...rest});
+  }
+});
+
+function renderPolygonsExample() {
+  const dataSource = vectorTableSource({
+    ...cartoConfig,
+    tableName: 'carto-demo-data.demo_tables.usa_counties'
+  });
+
+  const layers = [
     new VectorTileLayer({
       id: 'counties',
       pickable: true,
@@ -50,25 +76,98 @@ const deck = new Deck({
       lineWidthMinPixels: 0.5,
       opacity: 0.9
     })
-  ],
-  getTooltip: ({ object }) =>
-    object && {
-      html: `
-        <strong>County</strong>: ${object.properties.name}<br/>
-        <strong>Population</strong>: ${object.properties.total_pop?.toLocaleString() || 'N/A'}
-      `
-    }
-});
+  ];
 
-// Add basemap
-const map = new maplibregl.Map({
-  container: 'map',
-  style: BASEMAP.POSITRON,
-  interactive: false
-});
-deck.setProps({
-  onViewStateChange: ({viewState}) => {
-    const {longitude, latitude, ...rest} = viewState;
-    map.jumpTo({center: [longitude, latitude], ...rest});
+  deck.setProps({
+    layers,
+    getTooltip: ({ object }) =>
+      object && {
+        html: `
+          <strong>County</strong>: ${object.properties.name}<br/>
+          <strong>Population</strong>: ${object.properties.total_pop?.toLocaleString() || 'N/A'}
+        `
+      }
+  });
+
+  // Update description
+  const descriptionEl = document.querySelector('#description');
+  if (descriptionEl) {
+    descriptionEl.textContent = 'The map displays US counties with labels showing county names, styled with population-based colors. Labels are automatically positioned and include collision detection to maintain readability.';
   }
+}
+
+function renderLinesExample() {
+  const dataSource = vectorTableSource({
+    ...cartoConfig,
+    tableName: 'carto-demo-data.demo_tables.bristol_cycle_network'
+  });
+
+  const layers = [
+    new VectorTileLayer({
+      id: 'cycle-network',
+      pickable: true,
+      data: dataSource,
+      autoLabels: true,
+      getText: f => f.properties.route_name,
+      pointType: 'text',
+      textSizeScale: 8,
+      getTextColor: [255, 255, 255, 255],
+      textOutlineColor: [0, 0, 0, 255],
+      textOutlineWidth: 6,
+      textFontSettings: {
+        sdf: true,
+      },
+      getLineColor: colorCategories({
+        attr: 'r_status',
+        domain: ['Existing', 'Aspirational', 'Proposed', 'Planned'],
+        colors: 'Bold'
+      }),
+      lineWidthMinPixels: 2,
+      opacity: 0.9
+    })
+  ];
+
+  deck.setProps({
+    layers,
+    getTooltip: ({ object }) =>
+      object && {
+        html: `
+          <strong>Route</strong>: ${object.properties.route_name || 'Unnamed'}<br/>
+          <strong>Status</strong>: ${object.properties.r_status || 'N/A'}
+        `
+      }
+  });
+
+  // Update description
+  const descriptionEl = document.querySelector('#description');
+  if (descriptionEl) {
+    descriptionEl.textContent = 'The map displays Bristol\'s cycle network with labels showing route names, styled by status (Existing, Aspirational, Proposed, Planned). Labels are automatically positioned along routes with collision detection.';
+  }
+}
+
+function switchExample(exampleType: string) {
+  const viewState = VIEW_STATES[exampleType];
+
+  deck.setProps({
+    initialViewState: {
+      ...viewState,
+      transitionDuration: 2000,
+      transitionInterpolator: new FlyToInterpolator()
+    }
+  });
+
+  if (exampleType === 'polygons') {
+    renderPolygonsExample();
+  } else if (exampleType === 'lines') {
+    renderLinesExample();
+  }
+}
+
+// Initialize with polygons example
+renderPolygonsExample();
+
+// Setup dropdown listener
+const selector = document.querySelector<HTMLSelectElement>('#example-selector');
+selector?.addEventListener('change', () => {
+  switchExample(selector.value);
 });

--- a/autolabels/index.ts
+++ b/autolabels/index.ts
@@ -110,10 +110,10 @@ function renderLinesExample() {
       autoLabels: true,
       getText: f => f.properties.route_name,
       pointType: 'text',
-      textSizeScale: 8,
-      getTextColor: [255, 255, 255, 255],
-      textOutlineColor: [0, 0, 0, 255],
-      textOutlineWidth: 6,
+      textSizeScale: 14,
+      getTextColor: [0, 0, 0, 255],
+      textOutlineColor: [255, 255, 255, 255],
+      textOutlineWidth: 7,
       textFontSettings: {
         sdf: true,
       },
@@ -122,7 +122,7 @@ function renderLinesExample() {
         domain: ['Existing', 'Aspirational', 'Proposed', 'Planned'],
         colors: 'Bold'
       }),
-      lineWidthMinPixels: 2,
+      lineWidthMinPixels: 3,
       opacity: 0.9
     })
   ];

--- a/autolabels/package.json
+++ b/autolabels/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "carto-deckgl-example-autolabels",
+  "version": "0.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "dev-local": "vite --config ../vite.config.local.mjs",
+    "build": "vite build",
+    "preview": "vite preview",
+    "link-deck": "yarn link @deck.gl/core && yarn link @deck.gl/layers && yarn link @deck.gl/geo-layers && yarn link @deck.gl/mesh-layers && yarn link @deck.gl/aggregation-layers && yarn link @deck.gl/carto && yarn link @deck.gl/extensions",
+    "unlink-deck": "yarn unlink @deck.gl/core && yarn link @deck.gl/layers && yarn link @deck.gl/geo-layers && yarn link @deck.gl/mesh-layers && yarn link @deck.gl/aggregation-layers && yarn link @deck.gl/carto && yarn link @deck.gl/extensions"
+  },
+  "devDependencies": {
+    "vite": "^4.5.0"
+  },
+  "dependencies": {
+    "@carto/api-client": "0.5.21",
+    "@deck.gl/aggregation-layers": "^9.2.0",
+    "@deck.gl/carto": "^9.2.0",
+    "@deck.gl/core": "^9.2.0",
+    "@deck.gl/extensions": "^9.2.0",
+    "@deck.gl/geo-layers": "^9.2.0",
+    "@deck.gl/layers": "^9.2.0",
+    "@deck.gl/mesh-layers": "^9.2.0",
+    "maplibre-gl": "^3.5.2"
+  }
+}

--- a/autolabels/style.css
+++ b/autolabels/style.css
@@ -1,0 +1,69 @@
+body,
+html {
+  height: 100%;
+  width: 100%;
+  overflow: hidden;
+  position: fixed;
+  font-family: Inter, sans-serif;
+  font-weight: 400;
+  font-size: 1rem;
+  margin: 0;
+}
+
+#map,
+canvas {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  max-height: 100%;
+}
+
+#app {
+  flex: 1 1 auto;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+#story-card {
+  padding: 1.75rem;
+  background: #fdfdfe;
+  box-shadow: 4px 4px 8px #30303099;
+  border-radius: 4px;
+  z-index: 1;
+  margin: 1.5rem;
+  max-width: 480px;
+  max-height: 100vh;
+  z-index: 10;
+  overflow: scroll;
+}
+
+h2 {
+  margin-top: 0.5rem;
+  margin-bottom: 1rem;
+}
+
+.overline {
+  font-size: .625rem;
+  font-weight: 600;
+  line-height: 1.2;
+  letter-spacing: .125rem;
+  text-transform: uppercase;
+  margin-bottom: 0.5rem;
+}
+
+.caption {
+  margin-top: 2.25rem;
+  margin-bottom: 0px;
+  font-size: 0.8rem;
+}
+
+code {
+  background-color: #f4f4f4;
+  padding: 2px 6px;
+  border-radius: 3px;
+  font-family: 'Courier New', monospace;
+  font-size: 0.9em;
+}

--- a/autolabels/style.css
+++ b/autolabels/style.css
@@ -7,6 +7,7 @@ html {
   font-family: Inter, sans-serif;
   font-weight: 400;
   font-size: 1rem;
+  line-height: 1.5;
   margin: 0;
 }
 

--- a/autolabels/style.css
+++ b/autolabels/style.css
@@ -68,3 +68,21 @@ code {
   font-family: 'Courier New', monospace;
   font-size: 0.9em;
 }
+
+.layer-selector {
+  margin-top: 1rem;
+  margin-bottom: 1rem;
+}
+
+select {
+  border-radius: 4px;
+  max-width: 100%;
+  padding: 0.5rem;
+  margin-top: 0.5rem;
+  display: block;
+  width: 100%;
+}
+
+select:hover {
+  cursor: pointer;
+}

--- a/autolabels/tsconfig.json
+++ b/autolabels/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "es2022",
+    "jsx": "react",
+    "strict": true,
+    "noImplicitAny": false,
+    "allowJs": true,
+    "checkJs": false,
+    "moduleResolution": "node",
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "noEmit": true,
+    "resolveJsonModule": true,
+    "skipLibCheck": true,
+    "baseUrl": "."
+  }
+}


### PR DESCRIPTION
  ## Summary
  This PR adds a new example demonstrating the `autoLabels` feature of VectorTileLayer available since deck.gl 9.2: https://deck.gl/docs/api-reference/carto/vector-tile-layer#autolabels

  The example includes two demonstrations accessible via a dropdown selector:
  - **Polygons**: US counties with automatic labels at centroids, styled by population
  - **Lines**: Bristol UK cycle network with labels along routes, styled by status

  ## Specs
  - Dropdown to switch between polygon and line demonstrations
  - Smooth view state transitions using `FlyToInterpolator` when switching between examples
  - Uses deck.gl 9.2 and @carto/api-client 0.5.21

  ## Screenshots
  ### Polygons Example
  <img width="1800" height="1039" alt="Screenshot 2025-10-29 at 18 39 52" src="https://github.com/user-attachments/assets/b736d626-ce67-46ab-997e-15d840ab33b9" />

  ### Lines Example
<img width="1800" height="1036" alt="Screenshot 2025-11-04 at 13 47 01" src="https://github.com/user-attachments/assets/0a3a3472-5ab9-4e28-a7c1-0a3df6d25bb3" />


  ## Test plan
  - ✅ Build successful
  - ✅ Dev server runs without errors
  - ✅ Both polygon and line examples display correctly
  - ✅ Labels have appropriate contrast against different backgrounds
  - ✅ Smooth transitions between examples
  - ✅ Consistent with other examples in structure and documentation
