### PR TITLE
feat: add hello world agentic tools example

### DIFF
--- a/hello-world-agentic-tools/README.md
+++ b/hello-world-agentic-tools/README.md
@@ -1,31 +1,40 @@
-# Hello World — Agentic Tools
+## Example: Hello World Agentic Tools
 
-Minimal example of integrating [`@carto/agentic-deckgl`](https://www.npmjs.com/package/@carto/agentic-deckgl) with deck.gl using vanilla JavaScript.
+The smallest possible integration of [`@carto/agentic-deckgl`](https://www.npmjs.com/package/@carto/agentic-deckgl) with deck.gl using vanilla JavaScript.
 
-Type natural language into the chat panel and an AI agent will control the map — adding layers, changing the view, placing markers, and more.
+Type natural language into the chat panel and an AI agent controls the map — adding layers from CARTO demo data, changing the basemap, flying to locations, and placing markers.
+
+> [!WARNING]
+> This example needs a **Node backend** to keep your AI provider key off the browser, so it cannot run in StackBlitz. Clone the repo and run it locally.
+
+> [!NOTE]
+> For a richer setup with MCP, multiple SDKs (Vercel AI / OpenAI Agents / Google ADK), and frontend variants (React, Vue, Angular, vanilla), see [ai-tools-advanced-integrations](../ai-tools-advanced-integrations/).
 
 ## Architecture
 
-```
-frontend/          Vanilla JS + deck.gl + MapLibre (Vite dev server)
-  main.js          Map, chat UI, WebSocket client, tool executor
-  index.html       Single-page HTML shell
+```text
+frontend/        Vanilla JS + deck.gl + MapLibre (Vite)
+  main.js        Map, chat UI, WebSocket client, tool executor
+  index.html     Single-page HTML shell
 
-backend/           Node.js + Express + WebSocket
-  server.js        Connects to CARTO AI provider, runs @carto/agentic-deckgl
-                   tools via Vercel AI SDK, streams responses to the frontend
+backend/         Node.js + Express + WebSocket
+  server.js      Connects to a CARTO AI provider, runs @carto/agentic-deckgl
+                 tools via the Vercel AI SDK, streams responses back
 ```
 
 **How it works:**
 
-1. User types a message in the chat panel
-2. Frontend sends it over WebSocket to the backend along with current map state
-3. Backend feeds the message to an LLM (via CARTO's OpenAI-compatible endpoint)
-4. The LLM calls `set-deck-state` / `set-marker` tools from `@carto/agentic-deckgl`
-5. Tool calls are forwarded to the frontend, which applies them via `@deck.gl/json` JSONConverter
-6. Streamed text responses appear in the chat panel
+1. User types a message in the chat panel.
+2. Frontend sends it over WebSocket to the backend along with current map state.
+3. Backend feeds the message to an LLM via CARTO's OpenAI-compatible endpoint.
+4. The LLM calls `set-deck-state` / `set-marker` tools from `@carto/agentic-deckgl`.
+5. Tool calls are forwarded to the frontend, which applies them via `@deck.gl/json` JSONConverter.
+6. Streamed text replies appear in the chat panel.
 
-## Quick Start
+## Usage
+
+> [!WARNING]
+> You'll need credentials for both a CARTO API access token (for the map data) and a CARTO AI / OpenAI-compatible endpoint (for the LLM). See `.env.example` in each folder.
 
 ### 1. Backend
 
@@ -45,15 +54,23 @@ npm install
 npm run dev
 ```
 
-Open http://localhost:5173 and start chatting.
+Open the URL Vite prints (default `http://localhost:5173`) and start chatting.
 
-## Environment Variables
+## Things to try
+
+- "Show populated places worldwide"
+- "Show POIs in the US styled by category"
+- "Fly to Manhattan"
+- "Show US population by H3 hexagons"
+- "Add a marker at the Eiffel Tower"
+
+## Environment variables
 
 ### Backend (`.env`)
 
 | Variable | Description |
 |---|---|
-| `CARTO_AI_API_BASE_URL` | CARTO AI LiteLLM-compatible endpoint |
+| `CARTO_AI_API_BASE_URL` | CARTO AI / OpenAI-compatible endpoint |
 | `CARTO_AI_API_KEY` | API key for the AI endpoint |
 | `CARTO_AI_API_MODEL` | Model name (default: `gpt-4o`) |
 | `PORT` | Server port (default: `3003`) |

--- a/hello-world-agentic-tools/README.md
+++ b/hello-world-agentic-tools/README.md
@@ -1,0 +1,68 @@
+# Hello World — Agentic Tools
+
+Minimal example of integrating [`@carto/agentic-deckgl`](https://www.npmjs.com/package/@carto/agentic-deckgl) with deck.gl using vanilla JavaScript.
+
+Type natural language into the chat panel and an AI agent will control the map — adding layers, changing the view, placing markers, and more.
+
+## Architecture
+
+```
+frontend/          Vanilla JS + deck.gl + MapLibre (Vite dev server)
+  main.js          Map, chat UI, WebSocket client, tool executor
+  index.html       Single-page HTML shell
+
+backend/           Node.js + Express + WebSocket
+  server.js        Connects to CARTO AI provider, runs @carto/agentic-deckgl
+                   tools via Vercel AI SDK, streams responses to the frontend
+```
+
+**How it works:**
+
+1. User types a message in the chat panel
+2. Frontend sends it over WebSocket to the backend along with current map state
+3. Backend feeds the message to an LLM (via CARTO's OpenAI-compatible endpoint)
+4. The LLM calls `set-deck-state` / `set-marker` tools from `@carto/agentic-deckgl`
+5. Tool calls are forwarded to the frontend, which applies them via `@deck.gl/json` JSONConverter
+6. Streamed text responses appear in the chat panel
+
+## Quick Start
+
+### 1. Backend
+
+```bash
+cd backend
+cp .env.example .env   # fill in your CARTO AI credentials
+npm install
+npm run dev
+```
+
+### 2. Frontend
+
+```bash
+cd frontend
+cp .env.example .env   # fill in your CARTO API access token
+npm install
+npm run dev
+```
+
+Open http://localhost:5173 and start chatting.
+
+## Environment Variables
+
+### Backend (`.env`)
+
+| Variable | Description |
+|---|---|
+| `CARTO_AI_API_BASE_URL` | CARTO AI LiteLLM-compatible endpoint |
+| `CARTO_AI_API_KEY` | API key for the AI endpoint |
+| `CARTO_AI_API_MODEL` | Model name (default: `gpt-4o`) |
+| `PORT` | Server port (default: `3003`) |
+
+### Frontend (`.env`)
+
+| Variable | Description |
+|---|---|
+| `VITE_API_BASE_URL` | CARTO API base URL |
+| `VITE_API_ACCESS_TOKEN` | CARTO API access token (for rendering map layers) |
+| `VITE_CONNECTION_NAME` | CARTO connection name (default: `carto_dw`) |
+| `VITE_WS_URL` | Backend WebSocket URL (default: `ws://localhost:3003/ws`) |

--- a/hello-world-agentic-tools/README.md
+++ b/hello-world-agentic-tools/README.md
@@ -72,7 +72,7 @@ Open the URL Vite prints (default `http://localhost:5173`) and start chatting.
 |---|---|
 | `CARTO_AI_API_BASE_URL` | CARTO AI / OpenAI-compatible endpoint |
 | `CARTO_AI_API_KEY` | API key for the AI endpoint |
-| `CARTO_AI_API_MODEL` | Model name (default: `gpt-4o`) |
+| `CARTO_AI_API_MODEL` | Model name (default: `claude-sonnet-4-6`) |
 | `PORT` | Server port (default: `3003`) |
 
 ### Frontend (`.env`)

--- a/hello-world-agentic-tools/backend/.env.example
+++ b/hello-world-agentic-tools/backend/.env.example
@@ -1,7 +1,7 @@
 # CARTO AI provider (OpenAI-compatible endpoint)
 CARTO_AI_API_BASE_URL=https://your-carto-ai-endpoint.example.com/v1
 CARTO_AI_API_KEY=your-carto-api-key
-CARTO_AI_API_MODEL=gpt-4o
+CARTO_AI_API_MODEL=claude-sonnet-4-6
 
 # Server port
 PORT=3003

--- a/hello-world-agentic-tools/backend/.env.example
+++ b/hello-world-agentic-tools/backend/.env.example
@@ -1,0 +1,7 @@
+# CARTO AI provider (OpenAI-compatible endpoint)
+CARTO_AI_API_BASE_URL=https://your-carto-ai-endpoint.example.com/v1
+CARTO_AI_API_KEY=your-carto-api-key
+CARTO_AI_API_MODEL=gpt-4o
+
+# Server port
+PORT=3003

--- a/hello-world-agentic-tools/backend/package.json
+++ b/hello-world-agentic-tools/backend/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "hello-world-agentic-tools-backend",
+  "name": "carto-deckgl-example-hello-world-agentic-tools-backend",
   "version": "0.0.0",
   "private": true,
   "type": "module",

--- a/hello-world-agentic-tools/backend/package.json
+++ b/hello-world-agentic-tools/backend/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "hello-world-agentic-tools-backend",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "node --watch server.js"
+  },
+  "dependencies": {
+    "@ai-sdk/openai": "^3.0.30",
+    "@carto/agentic-deckgl": "^0.1.0",
+    "ai": "^6.0.94",
+    "cors": "^2.8.6",
+    "dotenv": "^16.3.1",
+    "express": "^4.18.2",
+    "ws": "^8.19.0"
+  }
+}

--- a/hello-world-agentic-tools/backend/server.js
+++ b/hello-world-agentic-tools/backend/server.js
@@ -11,7 +11,7 @@ import 'dotenv/config';
 import express from 'express';
 import cors from 'cors';
 import { createServer } from 'http';
-import { WebSocketServer, WebSocket } from 'ws';
+import { WebSocketServer } from 'ws';
 import { randomUUID } from 'crypto';
 import { createOpenAI } from '@ai-sdk/openai';
 import { ToolLoopAgent, stepCountIs, tool } from 'ai';
@@ -39,7 +39,7 @@ if (!CARTO_AI_API_BASE_URL || !CARTO_AI_API_KEY) {
 }
 
 // ---------------------------------------------------------------------------
-// AI Provider
+// AI provider
 // ---------------------------------------------------------------------------
 
 const carto = createOpenAI({
@@ -65,106 +65,40 @@ function createMapTools() {
 }
 
 // ---------------------------------------------------------------------------
-// Conversation history (minimal in-memory store)
+// Demo data catalog — tells the AI what tables are available.
+// Kept intentionally short for "hello world" — see the
+// ai-tools-advanced-integrations example for richer prompts.
+// ---------------------------------------------------------------------------
+
+const DEMO_DATA_PROMPT = `
+## Available data
+
+Connection: "carto_dw". Use ONLY these tables — do not invent table names.
+
+| Table | Source helper | Useful columns |
+|---|---|---|
+| carto-demo-data.demo_tables.populated_places | vectorTableSource | name, pop_max, adm0name (country) |
+| carto-demo-data.demo_tables.osm_pois_usa | vectorTableSource | name, group_name (category) |
+| carto-demo-data.demo_tables.usa_counties | vectorTableSource | name, state_name, total_pop |
+| cartobq.public_account.derived_spatialfeatures_usa_h3int_res8_v1_yearly_v2 | h3QuerySource | population, urbanity (H3 res 8) |
+
+Rules:
+- Use VectorTileLayer for vector tables, H3TileLayer for H3 tables.
+- For h3QuerySource, write \`SELECT * FROM <table>\` and an aggregationExp aliased as \`value\`
+  (e.g. "SUM(population) as value"); colorBins should then use attr "value".
+- When styling by a column, include "columns": ["<col>"] in the source config.
+- Do not set accessToken, apiBaseUrl, or connectionName — the frontend injects credentials.
+`;
+
+// ---------------------------------------------------------------------------
+// Conversation history (in-memory, per WebSocket connection — lost on reload)
 // ---------------------------------------------------------------------------
 
 const history = new Map(); // sessionId -> [{role, content}]
 
 // ---------------------------------------------------------------------------
-// Demo data catalog — tells the AI what tables are available
-// ---------------------------------------------------------------------------
-
-const DEMO_DATA_PROMPT = `
-## Available Data
-
-You MUST ONLY use the tables listed below. They all live in connection "carto_dw".
-Do NOT invent table names. If the user asks for data you don't have, say so.
-
-### Tables (vectorTableSource)
-| Table | Description | Key columns |
-|---|---|---|
-| carto-demo-data.demo_tables.populated_places | Major populated places worldwide | name, pop_max, adm0name (country), adm1name (state) |
-| carto-demo-data.demo_tables.osm_pois_usa | 1.4M Points of Interest across the US | name, group_name, subgroup_name, address |
-| carto-demo-data.demo_tables.usa_counties | US county boundaries | name, state_name, total_pop |
-| carto-demo-data.demo_tables.fires_worldwide | Global wildfire incidents | brightness, frp (fire radiative power), confidence |
-| carto-demo-data.demo_tables.riskanalysis_railroad_accidents | US railroad accidents | year, damage, county, state |
-
-### POI Categories (group_name values in osm_pois_usa)
-The group_name column has these exact values: Others, Education, Sustenance, Commercial, Entertainment, Arts & Culture, Financial, Tourism, Healthcare, Civic amenities, Transportation.
-
-**Styling POIs by category:** When asked to style POIs by category (group_name), ALWAYS use colorCategories with the Bold palette and include ALL category values in the domain. Do NOT use @@= expressions for this — there are too many categories and unmatched ones would appear grey.
-
-Example:
-{
-  "getFillColor": {
-    "@@function": "colorCategories",
-    "attr": "group_name",
-    "domain": ["Others", "Education", "Sustenance", "Commercial", "Entertainment, Arts & Culture", "Financial", "Tourism", "Healthcare", "Civic amenities", "Transportation"],
-    "colors": "Bold"
-  },
-  "updateTriggers": {
-    "getFillColor": { "attr": "group_name", "domain": ["Others", "Education", "Sustenance", "Commercial", "Entertainment, Arts & Culture", "Financial", "Tourism", "Healthcare", "Civic amenities", "Transportation"], "colors": "Bold" }
-  }
-}
-You MUST also include "columns": ["group_name"] in the data source.
-
-### County Population (usa_counties)
-The population column is "total_pop" (total population count). Use colorBins or colorContinuous for styling.
-Suggested domain for colorBins: [0, 50000, 100000, 500000, 1000000, 5000000].
-You MUST include "columns": ["total_pop"] in the data source when styling by population.
-
-### H3 Tables (h3QuerySource)
-| Table | Description | Key columns |
-|---|---|---|
-| cartobq.public_account.derived_spatialfeatures_usa_h3int_res8_v1_yearly_v2 | US spatial features aggregated at H3 resolution 8 | population, urbanity |
-
-**H3 usage rules:**
-- Use H3TileLayer with h3QuerySource for H3 tables.
-- h3QuerySource requires \`sqlQuery\` and \`aggregationExp\`. Do NOT use \`columns\` — it is not a valid parameter for h3QuerySource.
-- The \`aggregationExp\` MUST alias the result as \`value\` (e.g. \`SUM(population) as value\`). The \`attr\` in colorBins MUST match this alias: \`"value"\`.
-- You MUST include \`updateTriggers\` for \`getFillColor\` — without it the hexagons will appear grey.
-- H3 layers look best with the dark-matter basemap.
-
-**Complete H3 layer example:**
-\`\`\`json
-{
-  "@@type": "H3TileLayer",
-  "id": "h3-population",
-  "data": {
-    "@@function": "h3QuerySource",
-    "sqlQuery": "SELECT * FROM cartobq.public_account.derived_spatialfeatures_usa_h3int_res8_v1_yearly_v2",
-    "aggregationExp": "SUM(population) as value"
-  },
-  "opacity": 0.8,
-  "pickable": true,
-  "getFillColor": {
-    "@@function": "colorBins",
-    "attr": "value",
-    "domain": [0, 100, 1000, 10000, 100000, 1000000],
-    "colors": "PinkYl"
-  },
-  "updateTriggers": {
-    "getFillColor": { "attr": "value", "domain": [0, 100, 1000, 10000, 100000, 1000000], "colors": "PinkYl" }
-  }
-}
-\`\`\`
-
-### Usage rules
-- Use VectorTileLayer with vectorTableSource for vector tables.
-- Use H3TileLayer with h3QuerySource for H3 tables.
-- Connection name is always "carto_dw".
-- Do not set accessToken, apiBaseUrl, or connectionName — the frontend injects credentials automatically.
-
-### Spatial filtering (set-mask-layer)
-- The "enable-draw" action is NOT available. NEVER use it.
-- When the user asks to filter data to a specific area (city, neighborhood, region, etc.), you MUST generate the GeoJSON geometry yourself and call set-mask-layer with action "set" and the geometry.
-- Create an approximate bounding polygon for the area. For a city, use a rough rectangular or polygonal boundary. For example, for Manhattan you might use a 4-6 point polygon approximating its shape. For a circular area around a point, generate an approximate polygon with ~12 vertices.
-- You are expected to use your geographic knowledge to produce reasonable boundaries. They don't need to be exact administrative boundaries — a rough approximation is fine.
-- To clear a spatial filter, use action "clear".
-`;
-
-// ---------------------------------------------------------------------------
-// Agent runner
+// Strip CARTO credentials from anything we send to the frontend. Belt and
+// braces: tool call payloads should never carry them, but the AI may try.
 // ---------------------------------------------------------------------------
 
 const CREDENTIAL_FIELDS = ['accessToken', 'apiBaseUrl', 'connectionName', 'connection'];
@@ -182,24 +116,21 @@ function stripCredentials(data) {
   return data;
 }
 
+// ---------------------------------------------------------------------------
+// Agent runner
+// ---------------------------------------------------------------------------
+
 async function runAgent(userMessage, ws, sessionId, initialState) {
   const messageId = `msg_${Date.now()}`;
   const messages = history.get(sessionId) || [];
-
-  // Add user message to history
   messages.push({ role: 'user', content: userMessage });
 
-  const toolNames = [...consolidatedToolNames];
   const systemPrompt = buildSystemPrompt({
-    toolNames,
-    initialState: initialState
-      ? {
-          viewState: initialState.viewState,
-          initialViewState: initialState.initialViewState,
-          layers: initialState.layers,
-          activeLayerId: initialState.activeLayerId,
-        }
-      : undefined,
+    toolNames: [...consolidatedToolNames],
+    initialState: initialState && {
+      viewState: initialState.viewState,
+      layers: initialState.layers,
+    },
     additionalPrompt: DEMO_DATA_PROMPT,
   });
 
@@ -211,10 +142,7 @@ async function runAgent(userMessage, ws, sessionId, initialState) {
   });
 
   try {
-    const streamResult = await agent.stream({
-      messages: messages.map((m) => ({ role: m.role, content: m.content })),
-    });
-
+    const streamResult = await agent.stream({ messages });
     let fullText = '';
 
     for await (const part of streamResult.fullStream) {
@@ -250,10 +178,8 @@ async function runAgent(userMessage, ws, sessionId, initialState) {
       }
     }
 
-    // Signal completion
     ws.send(JSON.stringify({ type: 'stream_chunk', content: '', messageId, isComplete: true }));
 
-    // Save assistant reply to history
     const text = (await streamResult.text) || fullText || '';
     messages.push({ role: 'assistant', content: text });
     history.set(sessionId, messages);
@@ -289,16 +215,11 @@ wss.on('connection', (ws) => {
       if (msg.type === 'chat_message') {
         await runAgent(msg.content, ws, sid, msg.initialState);
       } else if (msg.type === 'tool_result') {
-        // Acknowledge tool results from the frontend
+        // Frontend acknowledgement — log for debugging only. The agent already
+        // has the tool's return value from its own loop, so we don't replay
+        // these into history.
         const status = msg.success ? 'success' : 'failed';
-        console.log(`[WS] Tool result: ${msg.toolName} — ${status}`);
-
-        const h = history.get(sid) || [];
-        h.push({
-          role: 'assistant',
-          content: `[Tool ${status}: ${msg.toolName}] ${msg.message}`,
-        });
-        history.set(sid, h);
+        console.log(`[WS] Tool ack: ${msg.toolName} — ${status}`);
       }
     } catch (err) {
       console.error('[WS] Error:', err);

--- a/hello-world-agentic-tools/backend/server.js
+++ b/hello-world-agentic-tools/backend/server.js
@@ -1,0 +1,321 @@
+/**
+ * Hello World Agentic Tools — Backend
+ *
+ * Minimal Express + WebSocket server that connects to a CARTO AI provider
+ * and exposes @carto/agentic-deckgl tools for map control via natural language.
+ *
+ * One file. No MCP, no semantic layer, no custom tools.
+ */
+
+import 'dotenv/config';
+import express from 'express';
+import cors from 'cors';
+import { createServer } from 'http';
+import { WebSocketServer, WebSocket } from 'ws';
+import { randomUUID } from 'crypto';
+import { createOpenAI } from '@ai-sdk/openai';
+import { ToolLoopAgent, stepCountIs, tool } from 'ai';
+import {
+  getToolsForVercelAI,
+  consolidatedToolNames,
+  buildSystemPrompt,
+  isFrontendToolResult,
+} from '@carto/agentic-deckgl';
+
+// ---------------------------------------------------------------------------
+// Config
+// ---------------------------------------------------------------------------
+
+const {
+  CARTO_AI_API_BASE_URL,
+  CARTO_AI_API_KEY,
+  CARTO_AI_API_MODEL = 'gpt-4o',
+  PORT = '3003',
+} = process.env;
+
+if (!CARTO_AI_API_BASE_URL || !CARTO_AI_API_KEY) {
+  console.error('Missing CARTO_AI_API_BASE_URL or CARTO_AI_API_KEY in .env');
+  process.exit(1);
+}
+
+// ---------------------------------------------------------------------------
+// AI Provider
+// ---------------------------------------------------------------------------
+
+const carto = createOpenAI({
+  baseURL: CARTO_AI_API_BASE_URL,
+  apiKey: CARTO_AI_API_KEY,
+  name: 'carto',
+});
+
+const model = carto.chat(CARTO_AI_API_MODEL);
+
+// ---------------------------------------------------------------------------
+// Tools — only the consolidated map tools from @carto/agentic-deckgl
+// ---------------------------------------------------------------------------
+
+function createMapTools() {
+  const toolDefs = getToolsForVercelAI(consolidatedToolNames);
+  return Object.fromEntries(
+    toolDefs.map((def) => [
+      def.name,
+      tool({ description: def.description, inputSchema: def.inputSchema, execute: def.execute }),
+    ])
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Conversation history (minimal in-memory store)
+// ---------------------------------------------------------------------------
+
+const history = new Map(); // sessionId -> [{role, content}]
+
+// ---------------------------------------------------------------------------
+// Demo data catalog — tells the AI what tables are available
+// ---------------------------------------------------------------------------
+
+const DEMO_DATA_PROMPT = `
+## Available Data
+
+You MUST ONLY use the tables listed below. They all live in connection "carto_dw".
+Do NOT invent table names. If the user asks for data you don't have, say so.
+
+### Tables (vectorTableSource)
+| Table | Description | Key columns |
+|---|---|---|
+| carto-demo-data.demo_tables.populated_places | Major populated places worldwide | name, pop_max, adm0name (country), adm1name (state) |
+| carto-demo-data.demo_tables.osm_pois_usa | 1.4M Points of Interest across the US | name, group_name, subgroup_name, address |
+| carto-demo-data.demo_tables.usa_counties | US county boundaries | name, state_name, total_pop |
+| carto-demo-data.demo_tables.fires_worldwide | Global wildfire incidents | brightness, frp (fire radiative power), confidence |
+| carto-demo-data.demo_tables.riskanalysis_railroad_accidents | US railroad accidents | year, damage, county, state |
+
+### POI Categories (group_name values in osm_pois_usa)
+The group_name column has these exact values: Others, Education, Sustenance, Commercial, Entertainment, Arts & Culture, Financial, Tourism, Healthcare, Civic amenities, Transportation.
+
+**Styling POIs by category:** When asked to style POIs by category (group_name), ALWAYS use colorCategories with the Bold palette and include ALL category values in the domain. Do NOT use @@= expressions for this — there are too many categories and unmatched ones would appear grey.
+
+Example:
+{
+  "getFillColor": {
+    "@@function": "colorCategories",
+    "attr": "group_name",
+    "domain": ["Others", "Education", "Sustenance", "Commercial", "Entertainment, Arts & Culture", "Financial", "Tourism", "Healthcare", "Civic amenities", "Transportation"],
+    "colors": "Bold"
+  },
+  "updateTriggers": {
+    "getFillColor": { "attr": "group_name", "domain": ["Others", "Education", "Sustenance", "Commercial", "Entertainment, Arts & Culture", "Financial", "Tourism", "Healthcare", "Civic amenities", "Transportation"], "colors": "Bold" }
+  }
+}
+You MUST also include "columns": ["group_name"] in the data source.
+
+### County Population (usa_counties)
+The population column is "total_pop" (total population count). Use colorBins or colorContinuous for styling.
+Suggested domain for colorBins: [0, 50000, 100000, 500000, 1000000, 5000000].
+You MUST include "columns": ["total_pop"] in the data source when styling by population.
+
+### H3 Tables (h3QuerySource)
+| Table | Description | Key columns |
+|---|---|---|
+| cartobq.public_account.derived_spatialfeatures_usa_h3int_res8_v1_yearly_v2 | US spatial features aggregated at H3 resolution 8 | population, urbanity |
+
+**H3 usage rules:**
+- Use H3TileLayer with h3QuerySource for H3 tables.
+- h3QuerySource requires \`sqlQuery\` and \`aggregationExp\`. Do NOT use \`columns\` — it is not a valid parameter for h3QuerySource.
+- The \`aggregationExp\` MUST alias the result as \`value\` (e.g. \`SUM(population) as value\`). The \`attr\` in colorBins MUST match this alias: \`"value"\`.
+- You MUST include \`updateTriggers\` for \`getFillColor\` — without it the hexagons will appear grey.
+- H3 layers look best with the dark-matter basemap.
+
+**Complete H3 layer example:**
+\`\`\`json
+{
+  "@@type": "H3TileLayer",
+  "id": "h3-population",
+  "data": {
+    "@@function": "h3QuerySource",
+    "sqlQuery": "SELECT * FROM cartobq.public_account.derived_spatialfeatures_usa_h3int_res8_v1_yearly_v2",
+    "aggregationExp": "SUM(population) as value"
+  },
+  "opacity": 0.8,
+  "pickable": true,
+  "getFillColor": {
+    "@@function": "colorBins",
+    "attr": "value",
+    "domain": [0, 100, 1000, 10000, 100000, 1000000],
+    "colors": "PinkYl"
+  },
+  "updateTriggers": {
+    "getFillColor": { "attr": "value", "domain": [0, 100, 1000, 10000, 100000, 1000000], "colors": "PinkYl" }
+  }
+}
+\`\`\`
+
+### Usage rules
+- Use VectorTileLayer with vectorTableSource for vector tables.
+- Use H3TileLayer with h3QuerySource for H3 tables.
+- Connection name is always "carto_dw".
+- Do not set accessToken, apiBaseUrl, or connectionName — the frontend injects credentials automatically.
+
+### Spatial filtering (set-mask-layer)
+- The "enable-draw" action is NOT available. NEVER use it.
+- When the user asks to filter data to a specific area (city, neighborhood, region, etc.), you MUST generate the GeoJSON geometry yourself and call set-mask-layer with action "set" and the geometry.
+- Create an approximate bounding polygon for the area. For a city, use a rough rectangular or polygonal boundary. For example, for Manhattan you might use a 4-6 point polygon approximating its shape. For a circular area around a point, generate an approximate polygon with ~12 vertices.
+- You are expected to use your geographic knowledge to produce reasonable boundaries. They don't need to be exact administrative boundaries — a rough approximation is fine.
+- To clear a spatial filter, use action "clear".
+`;
+
+// ---------------------------------------------------------------------------
+// Agent runner
+// ---------------------------------------------------------------------------
+
+const CREDENTIAL_FIELDS = ['accessToken', 'apiBaseUrl', 'connectionName', 'connection'];
+
+function stripCredentials(data) {
+  if (data === null || data === undefined) return data;
+  if (Array.isArray(data)) return data.map(stripCredentials);
+  if (typeof data === 'object') {
+    const result = {};
+    for (const [key, value] of Object.entries(data)) {
+      if (!CREDENTIAL_FIELDS.includes(key)) result[key] = stripCredentials(value);
+    }
+    return result;
+  }
+  return data;
+}
+
+async function runAgent(userMessage, ws, sessionId, initialState) {
+  const messageId = `msg_${Date.now()}`;
+  const messages = history.get(sessionId) || [];
+
+  // Add user message to history
+  messages.push({ role: 'user', content: userMessage });
+
+  const toolNames = [...consolidatedToolNames];
+  const systemPrompt = buildSystemPrompt({
+    toolNames,
+    initialState: initialState
+      ? {
+          viewState: initialState.viewState,
+          initialViewState: initialState.initialViewState,
+          layers: initialState.layers,
+          activeLayerId: initialState.activeLayerId,
+        }
+      : undefined,
+    additionalPrompt: DEMO_DATA_PROMPT,
+  });
+
+  const agent = new ToolLoopAgent({
+    model,
+    instructions: systemPrompt,
+    tools: createMapTools(),
+    stopWhen: stepCountIs(20),
+  });
+
+  try {
+    const streamResult = await agent.stream({
+      messages: messages.map((m) => ({ role: m.role, content: m.content })),
+    });
+
+    let fullText = '';
+
+    for await (const part of streamResult.fullStream) {
+      switch (part.type) {
+        case 'text-delta': {
+          const delta = part.text;
+          if (delta) {
+            fullText += delta;
+            ws.send(JSON.stringify({ type: 'stream_chunk', content: delta, messageId, isComplete: false }));
+          }
+          break;
+        }
+
+        case 'tool-result': {
+          if (isFrontendToolResult(part.output)) {
+            const fr = part.output;
+            ws.send(
+              JSON.stringify({
+                type: 'tool_call',
+                toolName: fr.toolName,
+                data: stripCredentials(fr.data),
+                callId: part.toolCallId,
+              })
+            );
+          }
+          break;
+        }
+
+        case 'error':
+          console.error('[Agent] Stream error:', part.error);
+          ws.send(JSON.stringify({ type: 'error', content: String(part.error) }));
+          break;
+      }
+    }
+
+    // Signal completion
+    ws.send(JSON.stringify({ type: 'stream_chunk', content: '', messageId, isComplete: true }));
+
+    // Save assistant reply to history
+    const text = (await streamResult.text) || fullText || '';
+    messages.push({ role: 'assistant', content: text });
+    history.set(sessionId, messages);
+  } catch (err) {
+    console.error('[Agent] Error:', err);
+    ws.send(JSON.stringify({ type: 'error', content: err.message || 'Agent error' }));
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Express + WebSocket server
+// ---------------------------------------------------------------------------
+
+const app = express();
+app.use(cors());
+app.use(express.json());
+
+const server = createServer(app);
+const wss = new WebSocketServer({ server, path: '/ws' });
+
+const sessions = new Map();
+
+wss.on('connection', (ws) => {
+  const sessionId = randomUUID();
+  sessions.set(ws, sessionId);
+  console.log(`[WS] Connected: ${sessionId}`);
+
+  ws.on('message', async (data) => {
+    try {
+      const msg = JSON.parse(data.toString());
+      const sid = sessions.get(ws);
+
+      if (msg.type === 'chat_message') {
+        await runAgent(msg.content, ws, sid, msg.initialState);
+      } else if (msg.type === 'tool_result') {
+        // Acknowledge tool results from the frontend
+        const status = msg.success ? 'success' : 'failed';
+        console.log(`[WS] Tool result: ${msg.toolName} — ${status}`);
+
+        const h = history.get(sid) || [];
+        h.push({
+          role: 'assistant',
+          content: `[Tool ${status}: ${msg.toolName}] ${msg.message}`,
+        });
+        history.set(sid, h);
+      }
+    } catch (err) {
+      console.error('[WS] Error:', err);
+      ws.send(JSON.stringify({ type: 'error', content: 'Invalid message' }));
+    }
+  });
+
+  ws.on('close', () => {
+    history.delete(sessions.get(ws));
+    sessions.delete(ws);
+    console.log('[WS] Disconnected');
+  });
+});
+
+app.get('/health', (_req, res) => res.json({ status: 'ok' }));
+
+server.listen(parseInt(PORT), () => {
+  console.log(`Server running on http://localhost:${PORT}`);
+  console.log(`WebSocket:  ws://localhost:${PORT}/ws`);
+});

--- a/hello-world-agentic-tools/backend/server.js
+++ b/hello-world-agentic-tools/backend/server.js
@@ -17,10 +17,14 @@ import { createOpenAI } from '@ai-sdk/openai';
 import { ToolLoopAgent, stepCountIs, tool } from 'ai';
 import {
   getToolsForVercelAI,
-  consolidatedToolNames,
+  TOOL_NAMES,
   buildSystemPrompt,
   isFrontendToolResult,
 } from '@carto/agentic-deckgl';
+
+// Hello-world supports a deliberately small subset of @carto/agentic-deckgl.
+// Drop set-mask-layer (no MaskExtension plumbing in this example).
+const ENABLED_TOOLS = [TOOL_NAMES.SET_DECK_STATE, TOOL_NAMES.SET_MARKER];
 
 // ---------------------------------------------------------------------------
 // Config
@@ -29,7 +33,7 @@ import {
 const {
   CARTO_AI_API_BASE_URL,
   CARTO_AI_API_KEY,
-  CARTO_AI_API_MODEL = 'gpt-4o',
+  CARTO_AI_API_MODEL = 'claude-sonnet-4-6',
   PORT = '3003',
 } = process.env;
 
@@ -55,7 +59,7 @@ const model = carto.chat(CARTO_AI_API_MODEL);
 // ---------------------------------------------------------------------------
 
 function createMapTools() {
-  const toolDefs = getToolsForVercelAI(consolidatedToolNames);
+  const toolDefs = getToolsForVercelAI(ENABLED_TOOLS);
   return Object.fromEntries(
     toolDefs.map((def) => [
       def.name,
@@ -71,23 +75,67 @@ function createMapTools() {
 // ---------------------------------------------------------------------------
 
 const DEMO_DATA_PROMPT = `
-## Available data
+## This example: hello world
 
-Connection: "carto_dw". Use ONLY these tables — do not invent table names.
+This is the *minimal* @carto/agentic-deckgl integration. The frontend supports
+a deliberately small set of features. Stay inside it.
+
+### What you CAN do
+
+- Navigate the camera (\`initialViewState\`) and change the basemap (\`mapStyle\`)
+  when explicitly asked.
+- Add, update, and remove deck.gl layers via \`set-deck-state\` using the data
+  catalog below. Layer styling (colorBins / colorCategories / colorContinuous,
+  opacity, radius, etc.) is fully supported.
+- Apply server-side data \`filters\` inside a source config (e.g.
+  \`"filters": { "group_name": { "in": { "values": ["Financial"] } } }\`).
+  Update or clear filters by re-sending the same layer ID with a new (or
+  empty) \`filters\` object. Wrap values in \`{ "values": [...] }\`.
+- Place pin markers with \`set-marker\` (\`add\` to drop one, \`clear-all\` to
+  remove them).
+
+### What you CANNOT do in this example (do NOT attempt)
+
+- **Widgets** — there is no widget panel. Never put a \`widgets\` array or
+  \`removeWidgetIds\` in your tool calls. If asked, say widgets are part of
+  the advanced example, not this one.
+- **Effects** — no effects pipeline. Never include an \`effects\` field.
+- **Spatial masks / drawing** — \`set-mask-layer\` is not available. There is
+  no \`enable-draw\` mode. If the user asks to filter by area, use a server-
+  side \`filters\` clause on a column (e.g. state_name, adm0name) when one
+  fits, or say the masking feature is not in this example.
+- **MCP / async workflows / semantic-layer queries** — none of those tools
+  exist here. Don't reference job IDs, async polling, or MCP results.
+- **Tooltips, legends, controls** — these are not configurable from tool
+  calls in this example.
+
+### Data catalog
+
+Connection: \`carto_dw\`. Use ONLY these tables — do not invent table names or
+columns. If the user asks for data not listed here, say you don't have it.
 
 | Table | Source helper | Useful columns |
 |---|---|---|
-| carto-demo-data.demo_tables.populated_places | vectorTableSource | name, pop_max, adm0name (country) |
+| carto-demo-data.demo_tables.populated_places | vectorTableSource | name, pop_max, adm0name (country), adm1name (state) |
 | carto-demo-data.demo_tables.osm_pois_usa | vectorTableSource | name, group_name (category) |
 | carto-demo-data.demo_tables.usa_counties | vectorTableSource | name, state_name, total_pop |
 | cartobq.public_account.derived_spatialfeatures_usa_h3int_res8_v1_yearly_v2 | h3QuerySource | population, urbanity (H3 res 8) |
 
-Rules:
-- Use VectorTileLayer for vector tables, H3TileLayer for H3 tables.
-- For h3QuerySource, write \`SELECT * FROM <table>\` and an aggregationExp aliased as \`value\`
-  (e.g. "SUM(population) as value"); colorBins should then use attr "value".
-- When styling by a column, include "columns": ["<col>"] in the source config.
-- Do not set accessToken, apiBaseUrl, or connectionName — the frontend injects credentials.
+\`group_name\` values in osm_pois_usa: Others, Education, Sustenance,
+Commercial, Entertainment, Arts & Culture, Financial, Tourism, Healthcare,
+Civic amenities, Transportation.
+
+### Rules of thumb
+
+- Use \`VectorTileLayer\` for vector tables, \`H3TileLayer\` for H3 tables.
+- For \`h3QuerySource\`, write \`SELECT * FROM <table>\` and an
+  \`aggregationExp\` aliased as \`value\` (e.g. \`"SUM(population) as value"\`);
+  matching \`colorBins\` should use \`attr: "value"\`.
+- When styling by a column, include \`"columns": ["<col>"]\` in the source
+  config so the column is fetched.
+- Never set \`accessToken\`, \`apiBaseUrl\`, or \`connectionName\` — the
+  frontend injects credentials automatically.
+- Be concise in chat replies. The map speaks for itself.
 `;
 
 // ---------------------------------------------------------------------------
@@ -126,7 +174,7 @@ async function runAgent(userMessage, ws, sessionId, initialState) {
   messages.push({ role: 'user', content: userMessage });
 
   const systemPrompt = buildSystemPrompt({
-    toolNames: [...consolidatedToolNames],
+    toolNames: ENABLED_TOOLS,
     initialState: initialState && {
       viewState: initialState.viewState,
       layers: initialState.layers,
@@ -206,6 +254,7 @@ wss.on('connection', (ws) => {
   const sessionId = randomUUID();
   sessions.set(ws, sessionId);
   console.log(`[WS] Connected: ${sessionId}`);
+  ws.send(JSON.stringify({ type: 'session_info', model: CARTO_AI_API_MODEL }));
 
   ws.on('message', async (data) => {
     try {

--- a/hello-world-agentic-tools/frontend/.env.example
+++ b/hello-world-agentic-tools/frontend/.env.example
@@ -1,0 +1,7 @@
+# CARTO API credentials (for rendering map layers)
+VITE_API_BASE_URL=https://gcp-us-east1.api.carto.com
+VITE_API_ACCESS_TOKEN=your_carto_access_token_here
+VITE_CONNECTION_NAME=carto_dw
+
+# Backend WebSocket URL
+VITE_WS_URL=ws://localhost:3003/ws

--- a/hello-world-agentic-tools/frontend/index.html
+++ b/hello-world-agentic-tools/frontend/index.html
@@ -50,6 +50,7 @@
 
       <!-- Chat panel -->
       <div id="chat">
+        <div id="chat-status"></div>
         <div id="chat-messages"></div>
         <form id="chat-form">
           <input

--- a/hello-world-agentic-tools/frontend/index.html
+++ b/hello-world-agentic-tools/frontend/index.html
@@ -1,0 +1,67 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link
+      rel="icon"
+      type="image/png"
+      sizes="32x32"
+      href="https://app.carto.com/favicon/favicon-32x32.png"
+    />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&display=swap"
+      rel="stylesheet"
+    />
+    <link
+      rel="stylesheet"
+      href="https://unpkg.com/maplibre-gl@5.12.0/dist/maplibre-gl.css"
+    />
+    <title>CARTO + deck.gl — Hello World Agentic Tools</title>
+  </head>
+  <body>
+    <div id="app">
+      <!-- Map -->
+      <div id="map"></div>
+      <canvas id="deck-canvas"></canvas>
+
+      <!-- Info panel -->
+      <div id="story-card">
+        <p class="overline">Hello World</p>
+        <h2>Agentic Tools</h2>
+        <p>
+          Minimal integration of
+          <a href="https://www.npmjs.com/package/@carto/agentic-deckgl"
+            >@carto/agentic-deckgl</a
+          >
+          with <a href="https://deck.gl">deck.gl</a> using vanilla JavaScript.
+        </p>
+        <p>
+          Type natural language into the chat panel and an AI agent will control
+          the map &mdash; adding layers, changing the view, and placing markers
+          using CARTO demo datasets.
+        </p>
+        <p class="caption">
+          Try: "Show populated places in the US" or "Show POIs in New York"
+        </p>
+      </div>
+
+      <!-- Chat panel -->
+      <div id="chat">
+        <div id="chat-messages"></div>
+        <form id="chat-form">
+          <input
+            id="chat-input"
+            type="text"
+            placeholder="Ask the AI to control the map..."
+            autocomplete="off"
+          />
+          <button type="submit">Send</button>
+        </form>
+      </div>
+    </div>
+    <script type="module" src="./main.js"></script>
+  </body>
+</html>

--- a/hello-world-agentic-tools/frontend/index.html
+++ b/hello-world-agentic-tools/frontend/index.html
@@ -50,6 +50,7 @@
 
       <!-- Chat panel -->
       <div id="chat">
+        <div id="chat-meta"></div>
         <div id="chat-status"></div>
         <div id="chat-messages"></div>
         <form id="chat-form">

--- a/hello-world-agentic-tools/frontend/main.js
+++ b/hello-world-agentic-tools/frontend/main.js
@@ -1,48 +1,29 @@
 /**
  * Hello World Agentic Tools — Frontend
  *
- * Minimal vanilla JS integration:
+ * Minimal vanilla-JS integration:
  *   1. deck.gl + MapLibre map
- *   2. WebSocket connection to the backend
- *   3. Chat UI that sends messages and renders streamed responses
- *   4. Tool executor that applies AI-generated map changes via JSONConverter
+ *   2. WebSocket connection to the backend agent
+ *   3. Chat UI that streams the assistant's text replies
+ *   4. Tool executor that applies AI-generated map changes through JSONConverter
  */
 
 import './style.css';
-import { Deck } from '@deck.gl/core';
+import { Deck, FlyToInterpolator } from '@deck.gl/core';
 import { BASEMAP } from '@deck.gl/carto';
 import maplibregl from 'maplibre-gl';
 import { JSONConverter } from '@deck.gl/json';
 import { TOOL_NAMES } from '@carto/agentic-deckgl';
 
-// deck.gl layer + source imports for JSONConverter registration
-import {
-  GeoJsonLayer,
-  ScatterplotLayer,
-  IconLayer,
-  ArcLayer,
-  LineLayer,
-  PolygonLayer,
-  TextLayer,
-  PathLayer,
-  PointCloudLayer,
-} from '@deck.gl/layers';
+import { ScatterplotLayer } from '@deck.gl/layers';
 import {
   VectorTileLayer,
   H3TileLayer,
-  QuadbinTileLayer,
   vectorTableSource,
-  vectorQuerySource,
-  h3TableSource,
   h3QuerySource,
-  quadbinTableSource,
-  quadbinQuerySource,
   colorBins,
   colorCategories,
-  colorContinuous,
 } from '@deck.gl/carto';
-import { FlyToInterpolator } from '@deck.gl/core';
-import { MaskExtension } from '@deck.gl/extensions';
 
 // ============================================================================
 // Environment
@@ -56,67 +37,33 @@ const env = {
 };
 
 // ============================================================================
-// JSONConverter — translates JSON specs from the AI into live deck.gl layers
+// JSONConverter — turns AI-authored JSON specs into live deck.gl layers.
+// CARTO source functions are wrapped so the user-supplied access token is
+// auto-injected; the AI never sees credentials.
 // ============================================================================
 
-function getCartoCredentials() {
-  return {
-    apiBaseUrl: env.apiBaseUrl,
-    accessToken: env.accessToken,
-    connectionName: env.connectionName,
-  };
-}
+const cartoCreds = {
+  apiBaseUrl: env.apiBaseUrl,
+  accessToken: env.accessToken,
+  connectionName: env.connectionName,
+};
 
-/** Wrap a CARTO source function so credentials are auto-injected */
-function wrapSource(sourceFn) {
-  return (config) => {
-    const creds = getCartoCredentials();
-    return sourceFn({
-      apiBaseUrl: config.apiBaseUrl || creds.apiBaseUrl,
-      accessToken: config.accessToken || creds.accessToken,
-      connectionName: config.connectionName || creds.connectionName,
-      ...config,
-    });
-  };
-}
+const wrapSource = (sourceFn) => (config) => sourceFn({ ...cartoCreds, ...config });
 
 const jsonConverter = new JSONConverter({
   configuration: {
-    classes: {
-      GeoJsonLayer,
-      ScatterplotLayer,
-      IconLayer,
-      ArcLayer,
-      LineLayer,
-      PolygonLayer,
-      TextLayer,
-      PathLayer,
-      PointCloudLayer,
-      VectorTileLayer,
-      H3TileLayer,
-      QuadbinTileLayer,
-      FlyToInterpolator,
-    },
-    constants: {
-      FlyToInterpolator: new FlyToInterpolator(),
-    },
+    classes: { ScatterplotLayer, VectorTileLayer, H3TileLayer },
     functions: {
       vectorTableSource: wrapSource(vectorTableSource),
-      vectorQuerySource: wrapSource(vectorQuerySource),
-      h3TableSource: wrapSource(h3TableSource),
       h3QuerySource: wrapSource(h3QuerySource),
-      quadbinTableSource: wrapSource(quadbinTableSource),
-      quadbinQuerySource: wrapSource(quadbinQuerySource),
       colorBins: (c) => colorBins({ attr: c.attr, domain: c.domain, colors: c.colors || 'PurpOr' }),
       colorCategories: (c) => colorCategories({ attr: c.attr, domain: c.domain, colors: c.colors || 'Bold' }),
-      colorContinuous: (c) => colorContinuous({ attr: c.attr, domain: c.domain, colors: c.colors || 'Sunset' }),
     },
-    enumerations: {},
   },
 });
 
 // ============================================================================
-// Map State
+// Map state
 // ============================================================================
 
 const INITIAL_VIEW_STATE = {
@@ -129,7 +76,6 @@ const INITIAL_VIEW_STATE = {
 
 let currentViewState = { ...INITIAL_VIEW_STATE };
 let layerSpecs = []; // raw JSON layer specs from the AI
-let maskGeometry = null; // GeoJSON geometry for MaskExtension clipping
 
 // ============================================================================
 // deck.gl + MapLibre
@@ -160,9 +106,7 @@ const deck = new Deck({
   getTooltip: ({ object }) => {
     if (!object) return null;
     const props = object.properties || object;
-    const entries = Object.entries(props)
-      .filter(([k]) => !['geom', 'geometry', 'the_geom', 'cartodb_id', 'id'].includes(k))
-      .slice(0, 5);
+    const entries = Object.entries(props).slice(0, 5);
     if (!entries.length) return null;
     return {
       html: entries.map(([k, v]) => `<b>${k}</b>: ${v}`).join('<br/>'),
@@ -171,62 +115,25 @@ const deck = new Deck({
   },
 });
 
-const MASK_ID = '__mask__';
-const maskExtension = new MaskExtension();
-
-/** Re-render layers from the current layerSpecs through JSONConverter */
 function renderLayers() {
   try {
-    const specsWithCreds = layerSpecs.map((layer) => {
-      const l = JSON.parse(JSON.stringify(layer));
-      if (l.data && typeof l.data === 'object' && l.data['@@function']) {
-        l.data.accessToken = env.accessToken;
-        l.data.apiBaseUrl = env.apiBaseUrl;
-        l.data.connectionName = env.connectionName;
-      }
-      return l;
-    });
-
-    const converted = jsonConverter.convert({ layers: specsWithCreds });
-    let layers = converted.layers || [];
-
-    // If mask is active, inject MaskExtension on data layers and add mask GeoJsonLayer
-    if (maskGeometry) {
-      layers = layers.map((l) =>
-        l.clone({
-          extensions: [...(l.props.extensions || []), maskExtension],
-          maskId: MASK_ID,
-        })
-      );
-
-      const geojson = maskGeometry.type === 'Feature' || maskGeometry.type === 'FeatureCollection'
-        ? maskGeometry
-        : { type: 'Feature', geometry: maskGeometry, properties: {} };
-
-      layers.push(
-        new GeoJsonLayer({
-          id: MASK_ID,
-          data: geojson,
-          operation: 'mask',
-        })
-      );
-    }
-
-    deck.setProps({ layers });
+    const { layers } = jsonConverter.convert({ layers: layerSpecs });
+    deck.setProps({ layers: layers || [] });
   } catch (err) {
     console.error('[Render] Failed to convert layers:', err);
   }
 }
 
 // ============================================================================
-// Tool Executor — handles set-deck-state tool calls from the AI
+// Tool executor — handles tool calls coming from the agent
 // ============================================================================
+
+const MARKERS_LAYER_ID = '__markers__';
 
 function executeTool(toolName, data) {
   if (toolName === TOOL_NAMES.SET_DECK_STATE) {
     const parts = [];
 
-    // View state
     if (data.initialViewState) {
       const vs = data.initialViewState;
       currentViewState = { ...currentViewState, ...vs };
@@ -240,7 +147,6 @@ function executeTool(toolName, data) {
       parts.push('viewState');
     }
 
-    // Basemap
     if (data.mapStyle) {
       const basemaps = {
         positron: BASEMAP.POSITRON,
@@ -251,7 +157,6 @@ function executeTool(toolName, data) {
       parts.push('basemap');
     }
 
-    // Layers
     if (data.removeLayerIds) {
       const remove = new Set(data.removeLayerIds);
       layerSpecs = layerSpecs.filter((l) => !remove.has(l.id));
@@ -261,14 +166,11 @@ function executeTool(toolName, data) {
       if (data.layers.length === 0) {
         layerSpecs = [];
       } else {
-        // Merge: update existing layers by id, append new ones
+        // Update layers by id, append new ones
         for (const incoming of data.layers) {
           const idx = layerSpecs.findIndex((l) => l.id === incoming.id);
-          if (idx >= 0) {
-            layerSpecs[idx] = { ...layerSpecs[idx], ...incoming };
-          } else {
-            layerSpecs.push(incoming);
-          }
+          if (idx >= 0) layerSpecs[idx] = { ...layerSpecs[idx], ...incoming };
+          else layerSpecs.push(incoming);
         }
       }
       parts.push(`${layerSpecs.length} layer(s)`);
@@ -279,20 +181,19 @@ function executeTool(toolName, data) {
   }
 
   if (toolName === TOOL_NAMES.SET_MARKER) {
-    // Minimal marker support — add a ScatterplotLayer dot
     const { latitude, longitude, action = 'add' } = data;
 
     if (action === 'clear-all') {
-      layerSpecs = layerSpecs.filter((l) => l.id !== '__markers__');
+      layerSpecs = layerSpecs.filter((l) => l.id !== MARKERS_LAYER_ID);
       renderLayers();
       return { success: true, message: 'Markers cleared' };
     }
 
-    let markerLayer = layerSpecs.find((l) => l.id === '__markers__');
+    let markerLayer = layerSpecs.find((l) => l.id === MARKERS_LAYER_ID);
     if (!markerLayer) {
       markerLayer = {
         '@@type': 'ScatterplotLayer',
-        id: '__markers__',
+        id: MARKERS_LAYER_ID,
         data: [],
         getPosition: '@@=coordinates',
         getFillColor: [51, 51, 51, 220],
@@ -301,46 +202,16 @@ function executeTool(toolName, data) {
         lineWidthMinPixels: 2,
         radiusMinPixels: 6,
         radiusMaxPixels: 6,
-        pickable: false,
       };
       layerSpecs.push(markerLayer);
     }
 
-    if (action === 'remove') {
-      markerLayer.data = markerLayer.data.filter(
-        (d) => Math.abs(d.coordinates[0] - longitude) > 0.00001 || Math.abs(d.coordinates[1] - latitude) > 0.00001
-      );
-    } else {
-      markerLayer.data.push({ coordinates: [longitude, latitude] });
-    }
-
+    markerLayer.data = [...markerLayer.data, { coordinates: [longitude, latitude] }];
     renderLayers();
-    return { success: true, message: `Marker ${action} at [${latitude}, ${longitude}]` };
+    return { success: true, message: `Marker placed at [${latitude}, ${longitude}]` };
   }
 
-  if (toolName === TOOL_NAMES.SET_MASK_LAYER) {
-    const { action, geometry } = data;
-
-    if (action === 'set' && geometry) {
-      maskGeometry = geometry;
-      renderLayers();
-      return { success: true, message: 'Mask applied — layers clipped to area' };
-    }
-
-    if (action === 'clear') {
-      maskGeometry = null;
-      renderLayers();
-      return { success: true, message: 'Mask cleared' };
-    }
-
-    if (action === 'enable-draw') {
-      return { success: false, message: 'Draw mode not supported in hello-world example' };
-    }
-
-    return { success: false, message: `Unknown mask action: ${action}` };
-  }
-
-  return { success: false, message: `Unknown tool: ${toolName}` };
+  return { success: false, message: `Unsupported tool: ${toolName}` };
 }
 
 // ============================================================================
@@ -350,8 +221,13 @@ function executeTool(toolName, data) {
 const messagesEl = document.getElementById('chat-messages');
 const formEl = document.getElementById('chat-form');
 const inputEl = document.getElementById('chat-input');
+const statusEl = document.getElementById('chat-status');
 
 let loaderEl = null;
+
+function setStatus(text) {
+  if (statusEl) statusEl.textContent = text;
+}
 
 function showLoader() {
   if (loaderEl) return;
@@ -384,13 +260,22 @@ function addMessage(type, text) {
 // ============================================================================
 
 let ws = null;
-let streamingEl = null; // element currently being streamed into
-let streamBuffer = '';   // accumulated text for current streaming message
+let streamingEl = null;
+let streamBuffer = '';
+
+// Layers the AI authored, excluding internal helpers (markers, etc.)
+const userLayers = () =>
+  layerSpecs
+    .filter((l) => !l.id?.startsWith('__'))
+    .map((l) => ({ id: l.id, type: l['@@type'] || 'Unknown', visible: l.visible !== false }));
 
 function connectWs() {
   ws = new WebSocket(env.wsUrl);
 
-  ws.onopen = () => console.log('[WS] Connected');
+  ws.onopen = () => {
+    setStatus('');
+    console.log('[WS] Connected');
+  };
 
   ws.onmessage = (event) => {
     const data = JSON.parse(event.data);
@@ -399,26 +284,20 @@ function connectWs() {
       case 'stream_chunk': {
         hideLoader();
         if (data.isComplete && !data.content) {
-          // Stream finished
-          if (streamingEl) streamingEl = null;
+          streamingEl = null;
           streamBuffer = '';
           break;
         }
         streamBuffer += data.content || '';
-        if (!streamingEl) {
-          streamingEl = addMessage('assistant', streamBuffer);
-        } else {
-          streamingEl.textContent = streamBuffer;
-          messagesEl.scrollTop = messagesEl.scrollHeight;
-        }
+        if (!streamingEl) streamingEl = addMessage('assistant', streamBuffer);
+        else streamingEl.textContent = streamBuffer;
+        messagesEl.scrollTop = messagesEl.scrollHeight;
         break;
       }
 
       case 'tool_call': {
         const result = executeTool(data.toolName, data.data);
         addMessage('tool', `${data.toolName}: ${result.message}`);
-
-        // Send result back to backend
         ws.send(
           JSON.stringify({
             type: 'tool_result',
@@ -426,9 +305,7 @@ function connectWs() {
             callId: data.callId,
             success: result.success,
             message: result.message,
-            layerState: layerSpecs
-              .filter((l) => !l.id?.startsWith('__'))
-              .map((l) => ({ id: l.id, type: l['@@type'] || 'Unknown', visible: l.visible !== false })),
+            layerState: userLayers(),
           })
         );
         break;
@@ -442,7 +319,7 @@ function connectWs() {
   };
 
   ws.onclose = () => {
-    console.log('[WS] Disconnected, reconnecting in 3s...');
+    setStatus('Disconnected — retrying…');
     setTimeout(connectWs, 3000);
   };
 
@@ -458,12 +335,14 @@ connectWs();
 formEl.addEventListener('submit', (e) => {
   e.preventDefault();
   const text = inputEl.value.trim();
-  if (!text || !ws || ws.readyState !== WebSocket.OPEN) return;
+  if (!text) return;
+  if (!ws || ws.readyState !== WebSocket.OPEN) {
+    addMessage('error', 'Not connected to backend yet — try again in a moment.');
+    return;
+  }
 
   addMessage('user', text);
   inputEl.value = '';
-
-  // Reset streaming state and show loader
   streamingEl = null;
   streamBuffer = '';
   showLoader();
@@ -481,13 +360,7 @@ formEl.addEventListener('submit', (e) => {
           pitch: currentViewState.pitch || 0,
           bearing: currentViewState.bearing || 0,
         },
-        layers: layerSpecs
-          .filter((l) => !l.id?.startsWith('__'))
-          .map((l) => ({
-            id: l.id,
-            type: l['@@type'] || 'Unknown',
-            visible: l.visible !== false,
-          })),
+        layers: userLayers(),
       },
     })
   );

--- a/hello-world-agentic-tools/frontend/main.js
+++ b/hello-world-agentic-tools/frontend/main.js
@@ -48,7 +48,7 @@ const cartoCreds = {
   connectionName: env.connectionName,
 };
 
-const wrapSource = (sourceFn) => (config) => sourceFn({ ...cartoCreds, ...config });
+const wrapSource = (sourceFn) => (config) => sourceFn({ ...config, ...cartoCreds });
 
 const jsonConverter = new JSONConverter({
   configuration: {

--- a/hello-world-agentic-tools/frontend/main.js
+++ b/hello-world-agentic-tools/frontend/main.js
@@ -1,0 +1,494 @@
+/**
+ * Hello World Agentic Tools — Frontend
+ *
+ * Minimal vanilla JS integration:
+ *   1. deck.gl + MapLibre map
+ *   2. WebSocket connection to the backend
+ *   3. Chat UI that sends messages and renders streamed responses
+ *   4. Tool executor that applies AI-generated map changes via JSONConverter
+ */
+
+import './style.css';
+import { Deck } from '@deck.gl/core';
+import { BASEMAP } from '@deck.gl/carto';
+import maplibregl from 'maplibre-gl';
+import { JSONConverter } from '@deck.gl/json';
+import { TOOL_NAMES } from '@carto/agentic-deckgl';
+
+// deck.gl layer + source imports for JSONConverter registration
+import {
+  GeoJsonLayer,
+  ScatterplotLayer,
+  IconLayer,
+  ArcLayer,
+  LineLayer,
+  PolygonLayer,
+  TextLayer,
+  PathLayer,
+  PointCloudLayer,
+} from '@deck.gl/layers';
+import {
+  VectorTileLayer,
+  H3TileLayer,
+  QuadbinTileLayer,
+  vectorTableSource,
+  vectorQuerySource,
+  h3TableSource,
+  h3QuerySource,
+  quadbinTableSource,
+  quadbinQuerySource,
+  colorBins,
+  colorCategories,
+  colorContinuous,
+} from '@deck.gl/carto';
+import { FlyToInterpolator } from '@deck.gl/core';
+import { MaskExtension } from '@deck.gl/extensions';
+
+// ============================================================================
+// Environment
+// ============================================================================
+
+const env = {
+  apiBaseUrl: import.meta.env.VITE_API_BASE_URL || 'https://gcp-us-east1.api.carto.com',
+  accessToken: import.meta.env.VITE_API_ACCESS_TOKEN || '',
+  connectionName: import.meta.env.VITE_CONNECTION_NAME || 'carto_dw',
+  wsUrl: import.meta.env.VITE_WS_URL || 'ws://localhost:3003/ws',
+};
+
+// ============================================================================
+// JSONConverter — translates JSON specs from the AI into live deck.gl layers
+// ============================================================================
+
+function getCartoCredentials() {
+  return {
+    apiBaseUrl: env.apiBaseUrl,
+    accessToken: env.accessToken,
+    connectionName: env.connectionName,
+  };
+}
+
+/** Wrap a CARTO source function so credentials are auto-injected */
+function wrapSource(sourceFn) {
+  return (config) => {
+    const creds = getCartoCredentials();
+    return sourceFn({
+      apiBaseUrl: config.apiBaseUrl || creds.apiBaseUrl,
+      accessToken: config.accessToken || creds.accessToken,
+      connectionName: config.connectionName || creds.connectionName,
+      ...config,
+    });
+  };
+}
+
+const jsonConverter = new JSONConverter({
+  configuration: {
+    classes: {
+      GeoJsonLayer,
+      ScatterplotLayer,
+      IconLayer,
+      ArcLayer,
+      LineLayer,
+      PolygonLayer,
+      TextLayer,
+      PathLayer,
+      PointCloudLayer,
+      VectorTileLayer,
+      H3TileLayer,
+      QuadbinTileLayer,
+      FlyToInterpolator,
+    },
+    constants: {
+      FlyToInterpolator: new FlyToInterpolator(),
+    },
+    functions: {
+      vectorTableSource: wrapSource(vectorTableSource),
+      vectorQuerySource: wrapSource(vectorQuerySource),
+      h3TableSource: wrapSource(h3TableSource),
+      h3QuerySource: wrapSource(h3QuerySource),
+      quadbinTableSource: wrapSource(quadbinTableSource),
+      quadbinQuerySource: wrapSource(quadbinQuerySource),
+      colorBins: (c) => colorBins({ attr: c.attr, domain: c.domain, colors: c.colors || 'PurpOr' }),
+      colorCategories: (c) => colorCategories({ attr: c.attr, domain: c.domain, colors: c.colors || 'Bold' }),
+      colorContinuous: (c) => colorContinuous({ attr: c.attr, domain: c.domain, colors: c.colors || 'Sunset' }),
+    },
+    enumerations: {},
+  },
+});
+
+// ============================================================================
+// Map State
+// ============================================================================
+
+const INITIAL_VIEW_STATE = {
+  latitude: 39.8097343,
+  longitude: -98.5556199,
+  zoom: 4,
+  bearing: 0,
+  pitch: 0,
+};
+
+let currentViewState = { ...INITIAL_VIEW_STATE };
+let layerSpecs = []; // raw JSON layer specs from the AI
+let maskGeometry = null; // GeoJSON geometry for MaskExtension clipping
+
+// ============================================================================
+// deck.gl + MapLibre
+// ============================================================================
+
+const map = new maplibregl.Map({
+  container: 'map',
+  style: BASEMAP.POSITRON,
+  interactive: false,
+  center: [INITIAL_VIEW_STATE.longitude, INITIAL_VIEW_STATE.latitude],
+  zoom: INITIAL_VIEW_STATE.zoom,
+});
+
+const deck = new Deck({
+  canvas: 'deck-canvas',
+  initialViewState: INITIAL_VIEW_STATE,
+  controller: true,
+  layers: [],
+  onViewStateChange: ({ viewState }) => {
+    currentViewState = viewState;
+    map.jumpTo({
+      center: [viewState.longitude, viewState.latitude],
+      zoom: viewState.zoom,
+      bearing: viewState.bearing,
+      pitch: viewState.pitch,
+    });
+  },
+  getTooltip: ({ object }) => {
+    if (!object) return null;
+    const props = object.properties || object;
+    const entries = Object.entries(props)
+      .filter(([k]) => !['geom', 'geometry', 'the_geom', 'cartodb_id', 'id'].includes(k))
+      .slice(0, 5);
+    if (!entries.length) return null;
+    return {
+      html: entries.map(([k, v]) => `<b>${k}</b>: ${v}`).join('<br/>'),
+      className: 'deck-tooltip',
+    };
+  },
+});
+
+const MASK_ID = '__mask__';
+const maskExtension = new MaskExtension();
+
+/** Re-render layers from the current layerSpecs through JSONConverter */
+function renderLayers() {
+  try {
+    const specsWithCreds = layerSpecs.map((layer) => {
+      const l = JSON.parse(JSON.stringify(layer));
+      if (l.data && typeof l.data === 'object' && l.data['@@function']) {
+        l.data.accessToken = env.accessToken;
+        l.data.apiBaseUrl = env.apiBaseUrl;
+        l.data.connectionName = env.connectionName;
+      }
+      return l;
+    });
+
+    const converted = jsonConverter.convert({ layers: specsWithCreds });
+    let layers = converted.layers || [];
+
+    // If mask is active, inject MaskExtension on data layers and add mask GeoJsonLayer
+    if (maskGeometry) {
+      layers = layers.map((l) =>
+        l.clone({
+          extensions: [...(l.props.extensions || []), maskExtension],
+          maskId: MASK_ID,
+        })
+      );
+
+      const geojson = maskGeometry.type === 'Feature' || maskGeometry.type === 'FeatureCollection'
+        ? maskGeometry
+        : { type: 'Feature', geometry: maskGeometry, properties: {} };
+
+      layers.push(
+        new GeoJsonLayer({
+          id: MASK_ID,
+          data: geojson,
+          operation: 'mask',
+        })
+      );
+    }
+
+    deck.setProps({ layers });
+  } catch (err) {
+    console.error('[Render] Failed to convert layers:', err);
+  }
+}
+
+// ============================================================================
+// Tool Executor — handles set-deck-state tool calls from the AI
+// ============================================================================
+
+function executeTool(toolName, data) {
+  if (toolName === TOOL_NAMES.SET_DECK_STATE) {
+    const parts = [];
+
+    // View state
+    if (data.initialViewState) {
+      const vs = data.initialViewState;
+      currentViewState = { ...currentViewState, ...vs };
+      deck.setProps({
+        initialViewState: {
+          ...currentViewState,
+          transitionDuration: vs.transitionDuration || 1000,
+          transitionInterpolator: new FlyToInterpolator(),
+        },
+      });
+      parts.push('viewState');
+    }
+
+    // Basemap
+    if (data.mapStyle) {
+      const basemaps = {
+        positron: BASEMAP.POSITRON,
+        'dark-matter': BASEMAP.DARK_MATTER,
+        voyager: BASEMAP.VOYAGER,
+      };
+      if (basemaps[data.mapStyle]) map.setStyle(basemaps[data.mapStyle]);
+      parts.push('basemap');
+    }
+
+    // Layers
+    if (data.removeLayerIds) {
+      const remove = new Set(data.removeLayerIds);
+      layerSpecs = layerSpecs.filter((l) => !remove.has(l.id));
+    }
+
+    if (Array.isArray(data.layers)) {
+      if (data.layers.length === 0) {
+        layerSpecs = [];
+      } else {
+        // Merge: update existing layers by id, append new ones
+        for (const incoming of data.layers) {
+          const idx = layerSpecs.findIndex((l) => l.id === incoming.id);
+          if (idx >= 0) {
+            layerSpecs[idx] = { ...layerSpecs[idx], ...incoming };
+          } else {
+            layerSpecs.push(incoming);
+          }
+        }
+      }
+      parts.push(`${layerSpecs.length} layer(s)`);
+    }
+
+    renderLayers();
+    return { success: true, message: `Updated: ${parts.join(', ')}` };
+  }
+
+  if (toolName === TOOL_NAMES.SET_MARKER) {
+    // Minimal marker support — add a ScatterplotLayer dot
+    const { latitude, longitude, action = 'add' } = data;
+
+    if (action === 'clear-all') {
+      layerSpecs = layerSpecs.filter((l) => l.id !== '__markers__');
+      renderLayers();
+      return { success: true, message: 'Markers cleared' };
+    }
+
+    let markerLayer = layerSpecs.find((l) => l.id === '__markers__');
+    if (!markerLayer) {
+      markerLayer = {
+        '@@type': 'ScatterplotLayer',
+        id: '__markers__',
+        data: [],
+        getPosition: '@@=coordinates',
+        getFillColor: [51, 51, 51, 220],
+        getLineColor: [255, 255, 255, 200],
+        stroked: true,
+        lineWidthMinPixels: 2,
+        radiusMinPixels: 6,
+        radiusMaxPixels: 6,
+        pickable: false,
+      };
+      layerSpecs.push(markerLayer);
+    }
+
+    if (action === 'remove') {
+      markerLayer.data = markerLayer.data.filter(
+        (d) => Math.abs(d.coordinates[0] - longitude) > 0.00001 || Math.abs(d.coordinates[1] - latitude) > 0.00001
+      );
+    } else {
+      markerLayer.data.push({ coordinates: [longitude, latitude] });
+    }
+
+    renderLayers();
+    return { success: true, message: `Marker ${action} at [${latitude}, ${longitude}]` };
+  }
+
+  if (toolName === TOOL_NAMES.SET_MASK_LAYER) {
+    const { action, geometry } = data;
+
+    if (action === 'set' && geometry) {
+      maskGeometry = geometry;
+      renderLayers();
+      return { success: true, message: 'Mask applied — layers clipped to area' };
+    }
+
+    if (action === 'clear') {
+      maskGeometry = null;
+      renderLayers();
+      return { success: true, message: 'Mask cleared' };
+    }
+
+    if (action === 'enable-draw') {
+      return { success: false, message: 'Draw mode not supported in hello-world example' };
+    }
+
+    return { success: false, message: `Unknown mask action: ${action}` };
+  }
+
+  return { success: false, message: `Unknown tool: ${toolName}` };
+}
+
+// ============================================================================
+// Chat UI
+// ============================================================================
+
+const messagesEl = document.getElementById('chat-messages');
+const formEl = document.getElementById('chat-form');
+const inputEl = document.getElementById('chat-input');
+
+let loaderEl = null;
+
+function showLoader() {
+  if (loaderEl) return;
+  loaderEl = document.createElement('div');
+  loaderEl.className = 'msg loader';
+  loaderEl.innerHTML = '<span class="dot"></span><span class="dot"></span><span class="dot"></span>';
+  messagesEl.appendChild(loaderEl);
+  messagesEl.scrollTop = messagesEl.scrollHeight;
+}
+
+function hideLoader() {
+  if (loaderEl) {
+    loaderEl.remove();
+    loaderEl = null;
+  }
+}
+
+function addMessage(type, text) {
+  hideLoader();
+  const el = document.createElement('div');
+  el.className = `msg ${type}`;
+  el.textContent = text;
+  messagesEl.appendChild(el);
+  messagesEl.scrollTop = messagesEl.scrollHeight;
+  return el;
+}
+
+// ============================================================================
+// WebSocket
+// ============================================================================
+
+let ws = null;
+let streamingEl = null; // element currently being streamed into
+let streamBuffer = '';   // accumulated text for current streaming message
+
+function connectWs() {
+  ws = new WebSocket(env.wsUrl);
+
+  ws.onopen = () => console.log('[WS] Connected');
+
+  ws.onmessage = (event) => {
+    const data = JSON.parse(event.data);
+
+    switch (data.type) {
+      case 'stream_chunk': {
+        hideLoader();
+        if (data.isComplete && !data.content) {
+          // Stream finished
+          if (streamingEl) streamingEl = null;
+          streamBuffer = '';
+          break;
+        }
+        streamBuffer += data.content || '';
+        if (!streamingEl) {
+          streamingEl = addMessage('assistant', streamBuffer);
+        } else {
+          streamingEl.textContent = streamBuffer;
+          messagesEl.scrollTop = messagesEl.scrollHeight;
+        }
+        break;
+      }
+
+      case 'tool_call': {
+        const result = executeTool(data.toolName, data.data);
+        addMessage('tool', `${data.toolName}: ${result.message}`);
+
+        // Send result back to backend
+        ws.send(
+          JSON.stringify({
+            type: 'tool_result',
+            toolName: data.toolName,
+            callId: data.callId,
+            success: result.success,
+            message: result.message,
+            layerState: layerSpecs
+              .filter((l) => !l.id?.startsWith('__'))
+              .map((l) => ({ id: l.id, type: l['@@type'] || 'Unknown', visible: l.visible !== false })),
+          })
+        );
+        break;
+      }
+
+      case 'error':
+        hideLoader();
+        addMessage('error', data.content);
+        break;
+    }
+  };
+
+  ws.onclose = () => {
+    console.log('[WS] Disconnected, reconnecting in 3s...');
+    setTimeout(connectWs, 3000);
+  };
+
+  ws.onerror = (err) => console.error('[WS] Error:', err);
+}
+
+connectWs();
+
+// ============================================================================
+// Send messages
+// ============================================================================
+
+formEl.addEventListener('submit', (e) => {
+  e.preventDefault();
+  const text = inputEl.value.trim();
+  if (!text || !ws || ws.readyState !== WebSocket.OPEN) return;
+
+  addMessage('user', text);
+  inputEl.value = '';
+
+  // Reset streaming state and show loader
+  streamingEl = null;
+  streamBuffer = '';
+  showLoader();
+
+  ws.send(
+    JSON.stringify({
+      type: 'chat_message',
+      content: text,
+      timestamp: Date.now(),
+      initialState: {
+        viewState: {
+          longitude: currentViewState.longitude,
+          latitude: currentViewState.latitude,
+          zoom: currentViewState.zoom,
+          pitch: currentViewState.pitch || 0,
+          bearing: currentViewState.bearing || 0,
+        },
+        layers: layerSpecs
+          .filter((l) => !l.id?.startsWith('__'))
+          .map((l) => ({
+            id: l.id,
+            type: l['@@type'] || 'Unknown',
+            visible: l.visible !== false,
+          })),
+      },
+    })
+  );
+});

--- a/hello-world-agentic-tools/frontend/main.js
+++ b/hello-world-agentic-tools/frontend/main.js
@@ -222,6 +222,7 @@ const messagesEl = document.getElementById('chat-messages');
 const formEl = document.getElementById('chat-form');
 const inputEl = document.getElementById('chat-input');
 const statusEl = document.getElementById('chat-status');
+const metaEl = document.getElementById('chat-meta');
 
 let loaderEl = null;
 
@@ -281,6 +282,10 @@ function connectWs() {
     const data = JSON.parse(event.data);
 
     switch (data.type) {
+      case 'session_info':
+        if (metaEl) metaEl.textContent = `model: ${data.model}`;
+        break;
+
       case 'stream_chunk': {
         hideLoader();
         if (data.isComplete && !data.content) {

--- a/hello-world-agentic-tools/frontend/package.json
+++ b/hello-world-agentic-tools/frontend/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "hello-world-agentic-tools-frontend",
+  "name": "carto-deckgl-example-hello-world-agentic-tools-frontend",
   "version": "0.0.0",
   "private": true,
   "type": "module",
@@ -11,7 +11,6 @@
     "@carto/agentic-deckgl": "^0.1.0",
     "@deck.gl/carto": "^9.2.2",
     "@deck.gl/core": "^9.2.2",
-    "@deck.gl/extensions": "^9.2.6",
     "@deck.gl/geo-layers": "^9.2.6",
     "@deck.gl/json": "^9.2.6",
     "@deck.gl/layers": "^9.2.2",
@@ -19,6 +18,6 @@
     "maplibre-gl": "^5.12.0"
   },
   "devDependencies": {
-    "vite": "^6.0.0"
+    "vite": "^4.5.0"
   }
 }

--- a/hello-world-agentic-tools/frontend/package.json
+++ b/hello-world-agentic-tools/frontend/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "hello-world-agentic-tools-frontend",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build"
+  },
+  "dependencies": {
+    "@carto/agentic-deckgl": "^0.1.0",
+    "@deck.gl/carto": "^9.2.2",
+    "@deck.gl/core": "^9.2.2",
+    "@deck.gl/extensions": "^9.2.6",
+    "@deck.gl/geo-layers": "^9.2.6",
+    "@deck.gl/json": "^9.2.6",
+    "@deck.gl/layers": "^9.2.2",
+    "@deck.gl/mesh-layers": "^9.2.6",
+    "maplibre-gl": "^5.12.0"
+  },
+  "devDependencies": {
+    "vite": "^6.0.0"
+  }
+}

--- a/hello-world-agentic-tools/frontend/style.css
+++ b/hello-world-agentic-tools/frontend/style.css
@@ -90,6 +90,18 @@ html {
   z-index: 10;
 }
 
+#chat-meta {
+  font-size: 11px;
+  color: #888;
+  padding: 8px 16px 0;
+  font-family: ui-monospace, SFMono-Regular, monospace;
+  word-break: break-all;
+}
+
+#chat-meta:empty {
+  display: none;
+}
+
 #chat-status {
   font-size: 12px;
   color: #c62828;

--- a/hello-world-agentic-tools/frontend/style.css
+++ b/hello-world-agentic-tools/frontend/style.css
@@ -90,6 +90,18 @@ html {
   z-index: 10;
 }
 
+#chat-status {
+  font-size: 12px;
+  color: #c62828;
+  padding: 0 16px;
+  min-height: 16px;
+  line-height: 16px;
+}
+
+#chat-status:empty {
+  display: none;
+}
+
 #chat-messages {
   flex: 1;
   overflow-y: auto;

--- a/hello-world-agentic-tools/frontend/style.css
+++ b/hello-world-agentic-tools/frontend/style.css
@@ -1,0 +1,202 @@
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body,
+html {
+  height: 100%;
+  width: 100%;
+  overflow: hidden;
+  position: fixed;
+  font-family: 'Inter', sans-serif;
+  font-weight: 400;
+  font-size: 1rem;
+  line-height: 1.5;
+}
+
+/* ---------- Map ---------- */
+
+#map,
+#deck-canvas {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+}
+
+/* ---------- Info panel (matches other examples) ---------- */
+
+#story-card {
+  position: absolute;
+  top: 0;
+  left: 0;
+  padding: 1.75rem;
+  background: #fdfdfe;
+  box-shadow: 4px 4px 8px #30303099;
+  border-radius: 4px;
+  z-index: 10;
+  margin: 1.5rem;
+  max-width: 400px;
+  max-height: calc(100vh - 3rem);
+  overflow: auto;
+  pointer-events: auto;
+}
+
+#story-card h2 {
+  margin-top: 0.5rem;
+  margin-bottom: 1rem;
+}
+
+#story-card p {
+  margin-bottom: 0.5rem;
+}
+
+#story-card a {
+  color: #036fe2;
+}
+
+.overline {
+  font-size: 0.625rem;
+  font-weight: 600;
+  line-height: 1.2;
+  letter-spacing: 0.125rem;
+  text-transform: uppercase;
+  margin-bottom: 0.5rem;
+}
+
+.caption {
+  margin-top: 1.5rem;
+  margin-bottom: 0;
+  font-size: 0.8rem;
+}
+
+/* ---------- Chat panel ---------- */
+
+#chat {
+  position: absolute;
+  top: 16px;
+  right: 16px;
+  bottom: 16px;
+  width: 360px;
+  background: #fff;
+  border-radius: 12px;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.15);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  z-index: 10;
+}
+
+#chat-messages {
+  flex: 1;
+  overflow-y: auto;
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.msg {
+  max-width: 90%;
+  padding: 10px 14px;
+  border-radius: 12px;
+  font-size: 14px;
+  line-height: 1.45;
+  word-wrap: break-word;
+  white-space: pre-wrap;
+}
+
+.msg.user {
+  align-self: flex-end;
+  background: #036fe2;
+  color: #fff;
+}
+
+.msg.assistant {
+  align-self: flex-start;
+  background: #f0f0f0;
+  color: #222;
+}
+
+.msg.tool {
+  align-self: flex-start;
+  background: #e8f5e9;
+  color: #2e7d32;
+  font-size: 12px;
+  padding: 6px 10px;
+}
+
+.msg.error {
+  align-self: flex-start;
+  background: #fbe9e7;
+  color: #c62828;
+  font-size: 12px;
+}
+
+/* ---------- Chat form ---------- */
+
+#chat-form {
+  display: flex;
+  border-top: 1px solid #e0e0e0;
+}
+
+#chat-input {
+  flex: 1;
+  border: none;
+  padding: 14px 16px;
+  font-size: 14px;
+  font-family: inherit;
+  outline: none;
+}
+
+#chat-form button {
+  background: #036fe2;
+  color: #fff;
+  border: none;
+  padding: 14px 20px;
+  font-size: 14px;
+  font-family: inherit;
+  cursor: pointer;
+}
+
+#chat-form button:hover {
+  background: #0256b3;
+}
+
+/* ---------- Loader ---------- */
+
+.msg.loader {
+  align-self: flex-start;
+  background: transparent;
+  padding: 6px 14px;
+  display: flex;
+  gap: 4px;
+}
+
+.msg.loader .dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: #999;
+  animation: pulse 1.2s ease-in-out infinite;
+}
+
+.msg.loader .dot:nth-child(2) { animation-delay: 0.2s; }
+.msg.loader .dot:nth-child(3) { animation-delay: 0.4s; }
+
+@keyframes pulse {
+  0%, 80%, 100% { opacity: 0.3; transform: scale(0.8); }
+  40% { opacity: 1; transform: scale(1); }
+}
+
+/* ---------- Tooltip ---------- */
+
+.deck-tooltip {
+  font-family: 'Inter', sans-serif;
+  font-size: 13px;
+  padding: 8px 12px;
+  border-radius: 6px;
+}

--- a/hello-world-agentic-tools/frontend/vite.config.js
+++ b/hello-world-agentic-tools/frontend/vite.config.js
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vite';
+
+export default defineConfig({
+  server: {
+    port: 5174,
+    open: true,
+  },
+});

--- a/hello-world-agentic-tools/frontend/vite.config.js
+++ b/hello-world-agentic-tools/frontend/vite.config.js
@@ -2,7 +2,6 @@ import { defineConfig } from 'vite';
 
 export default defineConfig({
   server: {
-    port: 5174,
     open: true,
   },
 });


### PR DESCRIPTION
## Summary

- Adds a new minimal example, `hello-world-agentic-tools/`, that integrates [`@carto/agentic-deckgl`](https://www.npmjs.com/package/@carto/agentic-deckgl) with deck.gl using vanilla JavaScript.
- A chat panel sends natural-language input over WebSocket to a small Express backend; the backend feeds it to an LLM (CARTO AI / OpenAI-compatible endpoint) that calls `set-deck-state` / `set-marker` tools, and the tool calls are streamed back to the frontend and applied via `@deck.gl/json`.
- Two folders: `backend/` (Node + Express + ws + Vercel AI SDK) and `frontend/` (Vite + deck.gl + MapLibre). `.env.example` files document the required CARTO credentials.

## Test plan

- [ ] `cd backend && cp .env.example .env` (fill in CARTO AI creds), `npm install`, `npm run dev`
- [ ] `cd frontend && cp .env.example .env` (fill in CARTO API token), `npm install`, `npm run dev`
- [ ] Open http://localhost:5173 and send a prompt that adds a layer (e.g. "show populated places worldwide") — verify the layer renders
- [ ] Send a prompt that changes the view (e.g. "fly to Manhattan") — verify the camera moves
- [ ] Send a prompt that places a marker — verify it appears on the map
- [ ] Confirm credentials (`accessToken`, `apiBaseUrl`, `connectionName`) are stripped from tool-call payloads in the WebSocket frames